### PR TITLE
multi-select-filters-sorting-refactor

### DIFF
--- a/__tests__/api/beers.route.test.ts
+++ b/__tests__/api/beers.route.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it, jest } from "@jest/globals";
 
-const mockedGetBeerOffers = jest.fn<(query?: { serving?: string }) => Promise<unknown[]>>();
+const mockedGetBeerOffersPage =
+  jest.fn<
+    (query?: { serving?: string }, page?: number) => Promise<{ offers: unknown[]; total: number }>
+  >();
 
 jest.mock("@/lib/query", () => ({
   createOfferOrPriceUpdateProposal: jest.fn(),
-  getBeerOffers: mockedGetBeerOffers,
+  getBeerOffersPage: mockedGetBeerOffersPage,
+  BEER_OFFERS_PAGE_SIZE: 20,
   getLocationContributionPermission: jest.fn(),
   getVariantContributionPermission: jest.fn(),
 }));
@@ -25,36 +29,35 @@ describe("GET /api/v1/beers", () => {
     expect(response.status).toBe(400);
     expect(body.status).toBe("error");
     expect(body.error.code).toBe("INVALID_QUERY");
-    expect(body.error.details?.some((detail) => detail.path === "sizeMl")).toBe(true);
-    expect(body.error.details?.some((detail) => detail.path === "serving")).toBe(true);
-    expect(mockedGetBeerOffers).not.toHaveBeenCalled();
+    expect(body.error.details?.some((detail) => detail.path === "sizeMl.0")).toBe(true);
+    expect(body.error.details?.some((detail) => detail.path === "serving.0")).toBe(true);
+    expect(mockedGetBeerOffersPage).not.toHaveBeenCalled();
   });
 
-  it("returns filtered offers when query params are valid", async () => {
-    mockedGetBeerOffers.mockResolvedValueOnce([
-      {
-        id: "offer-1",
-        brand: "Dithmarscher",
-        variant: "Pilsener",
-        variantId: "variant-1",
-        style: "Pilsner",
-        sizeMl: 500,
-        serving: "tap",
-        priceEur: 4.9,
-        locationId: "location-1",
+  it("returns filtered offers with pagination metadata when query params are valid", async () => {
+    const offer = {
+      id: "offer-1",
+      brand: "Dithmarscher",
+      variant: "Pilsener",
+      variantId: "variant-1",
+      style: "Pilsner",
+      sizeMl: 500,
+      serving: "tap",
+      priceEur: 4.9,
+      locationId: "location-1",
+      status: "approved",
+      createdById: null,
+      location: {
+        id: "location-1",
+        name: "Zum Test",
+        locationType: "pub",
+        district: "Mitte",
+        address: "Teststrasse 1",
         status: "approved",
         createdById: null,
-        location: {
-          id: "location-1",
-          name: "Zum Test",
-          locationType: "pub",
-          district: "Mitte",
-          address: "Teststrasse 1",
-          status: "approved",
-          createdById: null,
-        },
       },
-    ]);
+    };
+    mockedGetBeerOffersPage.mockResolvedValueOnce({ offers: [offer], total: 1 });
 
     const { GET } = await import("@/app/api/v1/beers/route");
     const request = new Request("http://localhost/api/v1/beers?serving=tap");
@@ -62,17 +65,23 @@ describe("GET /api/v1/beers", () => {
     const body = (await response.json()) as {
       status: string;
       data: {
-        count: number;
         filters: { serving?: string };
+        pagination: { page: number; pageSize: number; total: number; totalPages: number };
         offers: Array<{ id: string }>;
       };
     };
 
     expect(response.status).toBe(200);
     expect(body.status).toBe("ok");
-    expect(body.data.count).toBe(1);
-    expect(body.data.filters).toEqual({ serving: "tap" });
+    expect(body.data.filters).toEqual({ serving: ["tap"] });
+    expect(body.data.pagination.page).toBe(1);
+    expect(body.data.pagination.pageSize).toBe(20);
+    expect(body.data.pagination.total).toBe(1);
+    expect(body.data.pagination.totalPages).toBe(1);
     expect(body.data.offers[0]?.id).toBe("offer-1");
-    expect(mockedGetBeerOffers).toHaveBeenCalledWith({ serving: "tap" });
+    expect(mockedGetBeerOffersPage).toHaveBeenCalledWith(
+      expect.objectContaining({ serving: ["tap"] }),
+      1,
+    );
   });
 });

--- a/__tests__/lib/validation.test.ts
+++ b/__tests__/lib/validation.test.ts
@@ -21,11 +21,11 @@ describe("validation query parsing", () => {
       throw new Error("Expected beer query to parse.");
     }
 
-    expect(parsed.data.brandId).toBe("brand-1");
-    expect(parsed.data.sizeMl).toBe(500);
-    expect(parsed.data.serving).toBe("tap");
-    expect(parsed.data.locationType).toBe("pub");
-    expect(parsed.data.locationId).toBe("loc-1");
+    expect(parsed.data.brandId).toEqual(["brand-1", "brand-2"]);
+    expect(parsed.data.sizeMl).toEqual([500]);
+    expect(parsed.data.serving).toEqual(["tap"]);
+    expect(parsed.data.locationType).toEqual(["pub"]);
+    expect(parsed.data.locationId).toEqual(["loc-1"]);
   });
 
   it("rejects invalid beer query values", () => {
@@ -41,7 +41,7 @@ describe("validation query parsing", () => {
     }
 
     const issuePaths = parsed.error.issues.map((issue) => issue.path.join("."));
-    expect(issuePaths).toEqual(expect.arrayContaining(["sizeMl", "serving"]));
+    expect(issuePaths).toEqual(expect.arrayContaining(["sizeMl.0", "serving.0"]));
   });
 
   it("compacts blank URL params into undefined optional fields", () => {
@@ -54,7 +54,7 @@ describe("validation query parsing", () => {
     }
 
     expect(parsed.data.brandId).toBeUndefined();
-    expect(parsed.data.locationId).toBe("loc-9");
+    expect(parsed.data.locationId).toEqual(["loc-9"]);
   });
 
   it("requires locationId for review query params", () => {

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -66,15 +66,16 @@ Example response:
 
 ### `GET /beers` (public)
 
-Query parameters (all optional):
+Query parameters (all optional, filter params accept multiple values via repeated keys):
 
-- `brandId` (string)
-- `variantId` (string)
-- `styleId` (string)
-- `sizeMl` (integer, `1..2000`)
-- `serving` (`tap | bottle | can`)
-- `locationType` (`pub | bar | restaurant | supermarket`)
-- `locationId` (string)
+- `brandId` (string, repeatable — e.g. `?brandId=a&brandId=b`)
+- `variantId` (string, repeatable)
+- `styleId` (string, repeatable)
+- `sizeMl` (integer `1..2000`, repeatable)
+- `serving` (`tap | bottle | can`, repeatable)
+- `locationType` (`pub | bar | restaurant | supermarket`, repeatable)
+- `locationId` (string, repeatable)
+- `sort` (`price_asc | price_desc`, default `price_asc`, single value)
 
 Example:
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -2,7 +2,12 @@ import { PrismaClient } from "../src/generated/prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { Pool } from "pg";
 
+// ---------------------------------------------------------------------------
+// Locations
+// ---------------------------------------------------------------------------
+
 const locationSeed = [
+  // Pubs
   {
     id: "pogue-mahone",
     name: "Pogue Mahone Irish Pub",
@@ -11,12 +16,114 @@ const locationSeed = [
     address: "Bergstrasse 19, 24103 Kiel",
   },
   {
+    id: "flensburger-hof-pub",
+    name: "Flensburger Hof",
+    locationType: "pub",
+    district: "Vorstadt",
+    address: "Muhliusstrasse 33, 24103 Kiel",
+  },
+  {
+    id: "celtic-corner",
+    name: "Celtic Corner",
+    locationType: "pub",
+    district: "Gaarden",
+    address: "Elisabethstrasse 42, 24143 Kiel",
+  },
+  {
+    id: "zum-anker",
+    name: "Zum Anker",
+    locationType: "pub",
+    district: "Wik",
+    address: "Danziger Strasse 12, 24143 Kiel",
+  },
+  {
+    id: "alte-mole",
+    name: "Alte Mole",
+    locationType: "pub",
+    district: "Altstadt",
+    address: "Knooper Weg 5, 24103 Kiel",
+  },
+  {
+    id: "kieler-braustube",
+    name: "Kieler Braustube",
+    locationType: "pub",
+    district: "Ravensberg",
+    address: "Ravensberg Allee 9, 24118 Kiel",
+  },
+  {
+    id: "nordlicht-pub",
+    name: "Nordlicht Pub",
+    locationType: "pub",
+    district: "Neumühlen-Dietrichsdorf",
+    address: "Werftstrasse 21, 24143 Kiel",
+  },
+  {
+    id: "schwarzer-kater",
+    name: "Schwarzer Kater",
+    locationType: "pub",
+    district: "Brunswik",
+    address: "Niemannsweg 7, 24105 Kiel",
+  },
+
+  // Bars
+  {
     id: "hafenkante-bar",
     name: "Hafenkante Bar",
     locationType: "bar",
     district: "Duesternbrook",
     address: "Kiellinie 99, 24105 Kiel",
   },
+  {
+    id: "strandbar-schilksee",
+    name: "Strandbar Schilksee",
+    locationType: "bar",
+    district: "Schilksee",
+    address: "Strandweg 1, 24159 Kiel",
+  },
+  {
+    id: "foerde-lounge",
+    name: "Förde Lounge",
+    locationType: "bar",
+    district: "Altstadt",
+    address: "Holstenstrasse 60, 24103 Kiel",
+  },
+  {
+    id: "bierbar-gaarden",
+    name: "Bierbar Gaarden",
+    locationType: "bar",
+    district: "Gaarden",
+    address: "Gaardener Strasse 14, 24143 Kiel",
+  },
+  {
+    id: "sky-deck-bar",
+    name: "Sky Deck Bar",
+    locationType: "bar",
+    district: "Duesternbrook",
+    address: "Kiellinie 1, 24105 Kiel",
+  },
+  {
+    id: "tap-room-kiel",
+    name: "Tap Room Kiel",
+    locationType: "bar",
+    district: "Schrevenpark",
+    address: "Schrevenstrasse 8, 24118 Kiel",
+  },
+  {
+    id: "hafenblick-bar",
+    name: "Hafenblick Bar",
+    locationType: "bar",
+    district: "Wik",
+    address: "Kaistrasse 4, 24114 Kiel",
+  },
+  {
+    id: "studentenkeller",
+    name: "Studentenkeller",
+    locationType: "bar",
+    district: "Ravensberg",
+    address: "Universitaetsstrasse 2, 24118 Kiel",
+  },
+
+  // Restaurants
   {
     id: "foerde-brauhaus",
     name: "Foerde Brauhaus",
@@ -25,46 +132,167 @@ const locationSeed = [
     address: "Kehdenstrasse 12, 24103 Kiel",
   },
   {
+    id: "seehof-restaurant",
+    name: "Seehof Restaurant",
+    locationType: "restaurant",
+    district: "Duesternbrook",
+    address: "Düsternbrooker Weg 14, 24105 Kiel",
+  },
+  {
+    id: "kieler-yacht-club-restaurant",
+    name: "Kieler Yacht Club Restaurant",
+    locationType: "restaurant",
+    district: "Schilksee",
+    address: "Olympiaweg 4, 24159 Kiel",
+  },
+  {
+    id: "zum-goldenen-anker",
+    name: "Zum Goldenen Anker",
+    locationType: "restaurant",
+    district: "Altstadt",
+    address: "Nikolaistrasse 4, 24103 Kiel",
+  },
+  {
+    id: "brauhaus-am-schloss",
+    name: "Brauhaus am Schloss",
+    locationType: "restaurant",
+    district: "Altstadt",
+    address: "Wall 65, 24103 Kiel",
+  },
+  {
+    id: "nordkueche",
+    name: "Nordküche",
+    locationType: "restaurant",
+    district: "Gaarden",
+    address: "Vinetaplatz 6, 24143 Kiel",
+  },
+  {
+    id: "bootshaus-restaurant",
+    name: "Bootshaus Restaurant",
+    locationType: "restaurant",
+    district: "Wik",
+    address: "Reventloubrücke 1, 24105 Kiel",
+  },
+
+  // Supermarkets
+  {
     id: "marktfrisch-kiel",
     name: "Marktfrisch Kiel",
     locationType: "supermarket",
     district: "Gaarden",
     address: "Schoenberger Strasse 4, 24148 Kiel",
   },
+  {
+    id: "rewe-altstadt",
+    name: "REWE Altstadt",
+    locationType: "supermarket",
+    district: "Altstadt",
+    address: "Gutenbergstrasse 76, 24103 Kiel",
+  },
+  {
+    id: "edeka-ravensberg",
+    name: "EDEKA Ravensberg",
+    locationType: "supermarket",
+    district: "Ravensberg",
+    address: "Holtenauer Strasse 110, 24118 Kiel",
+  },
+  {
+    id: "netto-gaarden",
+    name: "Netto Gaarden",
+    locationType: "supermarket",
+    district: "Gaarden",
+    address: "Elisabethstrasse 15, 24143 Kiel",
+  },
+  {
+    id: "lidl-mettenhof",
+    name: "Lidl Mettenhof",
+    locationType: "supermarket",
+    district: "Mettenhof",
+    address: "Eckernfoerder Strasse 99, 24119 Kiel",
+  },
+  {
+    id: "aldi-nord-wik",
+    name: "ALDI Nord Wik",
+    locationType: "supermarket",
+    district: "Wik",
+    address: "Legienstrasse 40, 24114 Kiel",
+  },
+  {
+    id: "kaufland-hassee",
+    name: "Kaufland Hassee",
+    locationType: "supermarket",
+    district: "Hassee",
+    address: "Hamburger Chaussee 12, 24113 Kiel",
+  },
 ] as const;
+
+// ---------------------------------------------------------------------------
+// Beer Styles
+// ---------------------------------------------------------------------------
 
 const beerStyleSeed = [
   { id: "style-stout", name: "Stout" },
   { id: "style-red-ale", name: "Red Ale" },
   { id: "style-pils", name: "Pils" },
   { id: "style-hefeweizen", name: "Hefeweizen" },
+  { id: "style-lager", name: "Lager" },
+  { id: "style-ipa", name: "IPA" },
+  { id: "style-porter", name: "Porter" },
+  { id: "style-weizen", name: "Weizen" },
+  { id: "style-dunkel", name: "Dunkel" },
+  { id: "style-maerzen", name: "Märzen" },
+  { id: "style-koelsch", name: "Kölsch" },
+  { id: "style-altbier", name: "Altbier" },
 ] as const;
 
+// ---------------------------------------------------------------------------
+// Beer Brands
+// ---------------------------------------------------------------------------
+
 const beerBrandSeed = [
-  { id: "brand-guinness", name: "Guinness" },
-  { id: "brand-kilkenny", name: "Kilkenny" },
+  // German — North
   { id: "brand-becks", name: "Becks" },
   { id: "brand-astra", name: "Astra" },
   { id: "brand-flensburger", name: "Flensburger" },
-  { id: "brand-erdinger", name: "Erdinger" },
   { id: "brand-holsten", name: "Holsten" },
+  { id: "brand-jever", name: "Jever" },
+  // German — South/National
+  { id: "brand-erdinger", name: "Erdinger" },
+  { id: "brand-paulaner", name: "Paulaner" },
+  { id: "brand-weihenstephaner", name: "Weihenstephaner" },
+  { id: "brand-warsteiner", name: "Warsteiner" },
+  { id: "brand-bitburger", name: "Bitburger" },
+  { id: "brand-krombacher", name: "Krombacher" },
+  { id: "brand-veltins", name: "Veltins" },
+  { id: "brand-radeberger", name: "Radeberger" },
+  { id: "brand-augustiner", name: "Augustiner" },
+  { id: "brand-spaten", name: "Spaten" },
+  { id: "brand-hacker-pschorr", name: "Hacker-Pschorr" },
+  { id: "brand-oettinger", name: "Oettinger" },
+  { id: "brand-koenigsbacher", name: "Königsbacher" },
+  { id: "brand-kölsch-reissdorf", name: "Reissdorf" },
+  // Irish / British
+  { id: "brand-guinness", name: "Guinness" },
+  { id: "brand-kilkenny", name: "Kilkenny" },
+  { id: "brand-murphys", name: "Murphys" },
+  // International
+  { id: "brand-heineken", name: "Heineken" },
+  { id: "brand-stella", name: "Stella Artois" },
+  { id: "brand-corona", name: "Corona" },
 ] as const;
 
+// ---------------------------------------------------------------------------
+// Beer Variants
+// ---------------------------------------------------------------------------
+
 const beerVariantSeed = [
-  {
-    id: "variant-guinness-stout",
-    brandId: "brand-guinness",
-    styleId: "style-stout",
-    name: "Stout",
-  },
-  {
-    id: "variant-kilkenny-red-ale",
-    brandId: "brand-kilkenny",
-    styleId: "style-red-ale",
-    name: "Red Ale",
-  },
+  // Becks
   { id: "variant-becks-pils", brandId: "brand-becks", styleId: "style-pils", name: "Pils" },
+  { id: "variant-becks-gold", brandId: "brand-becks", styleId: "style-lager", name: "Gold" },
+  // Astra
   { id: "variant-astra-pils", brandId: "brand-astra", styleId: "style-pils", name: "Pils" },
+  { id: "variant-astra-urtyp", brandId: "brand-astra", styleId: "style-lager", name: "Urtyp" },
+  // Flensburger
   {
     id: "variant-flensburger-pils",
     brandId: "brand-flensburger",
@@ -72,80 +300,484 @@ const beerVariantSeed = [
     name: "Pils",
   },
   {
+    id: "variant-flensburger-weizen",
+    brandId: "brand-flensburger",
+    styleId: "style-weizen",
+    name: "Weizen",
+  },
+  // Holsten
+  { id: "variant-holsten-pils", brandId: "brand-holsten", styleId: "style-pils", name: "Pils" },
+  {
+    id: "variant-holsten-export",
+    brandId: "brand-holsten",
+    styleId: "style-lager",
+    name: "Export",
+  },
+  // Jever
+  { id: "variant-jever-pils", brandId: "brand-jever", styleId: "style-pils", name: "Pils" },
+  {
+    id: "variant-jever-fun",
+    brandId: "brand-jever",
+    styleId: "style-pils",
+    name: "Fun (Alkoholfrei)",
+  },
+  // Erdinger
+  {
     id: "variant-erdinger-hefeweizen",
     brandId: "brand-erdinger",
     styleId: "style-hefeweizen",
     name: "Hefeweizen",
   },
-  { id: "variant-holsten-pils", brandId: "brand-holsten", styleId: "style-pils", name: "Pils" },
+  {
+    id: "variant-erdinger-dunkel",
+    brandId: "brand-erdinger",
+    styleId: "style-dunkel",
+    name: "Dunkel",
+  },
+  // Paulaner
+  {
+    id: "variant-paulaner-hefeweizen",
+    brandId: "brand-paulaner",
+    styleId: "style-hefeweizen",
+    name: "Hefeweizen",
+  },
+  {
+    id: "variant-paulaner-maerzen",
+    brandId: "brand-paulaner",
+    styleId: "style-maerzen",
+    name: "Märzen",
+  },
+  {
+    id: "variant-paulaner-dunkel",
+    brandId: "brand-paulaner",
+    styleId: "style-dunkel",
+    name: "Dunkel",
+  },
+  // Weihenstephaner
+  {
+    id: "variant-weihenstephaner-hefeweizen",
+    brandId: "brand-weihenstephaner",
+    styleId: "style-hefeweizen",
+    name: "Hefeweizen",
+  },
+  {
+    id: "variant-weihenstephaner-pils",
+    brandId: "brand-weihenstephaner",
+    styleId: "style-pils",
+    name: "Pils",
+  },
+  // Warsteiner
+  {
+    id: "variant-warsteiner-pils",
+    brandId: "brand-warsteiner",
+    styleId: "style-pils",
+    name: "Premium Verum",
+  },
+  // Bitburger
+  {
+    id: "variant-bitburger-pils",
+    brandId: "brand-bitburger",
+    styleId: "style-pils",
+    name: "Premium Pils",
+  },
+  // Krombacher
+  {
+    id: "variant-krombacher-pils",
+    brandId: "brand-krombacher",
+    styleId: "style-pils",
+    name: "Pils",
+  },
+  {
+    id: "variant-krombacher-weizen",
+    brandId: "brand-krombacher",
+    styleId: "style-weizen",
+    name: "Weizen",
+  },
+  // Veltins
+  {
+    id: "variant-veltins-pils",
+    brandId: "brand-veltins",
+    styleId: "style-pils",
+    name: "Pilsener",
+  },
+  // Radeberger
+  {
+    id: "variant-radeberger-pils",
+    brandId: "brand-radeberger",
+    styleId: "style-pils",
+    name: "Pilsner",
+  },
+  // Augustiner
+  {
+    id: "variant-augustiner-lager",
+    brandId: "brand-augustiner",
+    styleId: "style-lager",
+    name: "Lagerbier Hell",
+  },
+  {
+    id: "variant-augustiner-hefeweizen",
+    brandId: "brand-augustiner",
+    styleId: "style-hefeweizen",
+    name: "Weissbier",
+  },
+  // Spaten
+  {
+    id: "variant-spaten-maerzen",
+    brandId: "brand-spaten",
+    styleId: "style-maerzen",
+    name: "Märzen",
+  },
+  {
+    id: "variant-spaten-lager",
+    brandId: "brand-spaten",
+    styleId: "style-lager",
+    name: "Münchner Hell",
+  },
+  // Hacker-Pschorr
+  {
+    id: "variant-hacker-pschorr-hefeweizen",
+    brandId: "brand-hacker-pschorr",
+    styleId: "style-hefeweizen",
+    name: "Weisse",
+  },
+  {
+    id: "variant-hacker-pschorr-dunkel",
+    brandId: "brand-hacker-pschorr",
+    styleId: "style-dunkel",
+    name: "Dunkel",
+  },
+  // Oettinger
+  {
+    id: "variant-oettinger-pils",
+    brandId: "brand-oettinger",
+    styleId: "style-pils",
+    name: "Pils",
+  },
+  {
+    id: "variant-oettinger-weizen",
+    brandId: "brand-oettinger",
+    styleId: "style-weizen",
+    name: "Weizen",
+  },
+  // Königsbacher
+  {
+    id: "variant-koenigsbacher-pils",
+    brandId: "brand-koenigsbacher",
+    styleId: "style-pils",
+    name: "Pils",
+  },
+  // Reissdorf
+  {
+    id: "variant-reissdorf-koelsch",
+    brandId: "brand-kölsch-reissdorf",
+    styleId: "style-koelsch",
+    name: "Kölsch",
+  },
+  // Guinness
+  {
+    id: "variant-guinness-stout",
+    brandId: "brand-guinness",
+    styleId: "style-stout",
+    name: "Stout",
+  },
+  // Kilkenny
+  {
+    id: "variant-kilkenny-red-ale",
+    brandId: "brand-kilkenny",
+    styleId: "style-red-ale",
+    name: "Red Ale",
+  },
+  // Murphys
+  {
+    id: "variant-murphys-stout",
+    brandId: "brand-murphys",
+    styleId: "style-stout",
+    name: "Irish Stout",
+  },
+  {
+    id: "variant-murphys-red",
+    brandId: "brand-murphys",
+    styleId: "style-red-ale",
+    name: "Irish Red",
+  },
+  // Heineken
+  {
+    id: "variant-heineken-lager",
+    brandId: "brand-heineken",
+    styleId: "style-lager",
+    name: "Lager",
+  },
+  // Stella Artois
+  {
+    id: "variant-stella-lager",
+    brandId: "brand-stella",
+    styleId: "style-lager",
+    name: "Lager",
+  },
+  // Corona
+  {
+    id: "variant-corona-extra",
+    brandId: "brand-corona",
+    styleId: "style-lager",
+    name: "Extra",
+  },
 ] as const;
 
-const beerOfferSeed = [
-  {
-    id: "offer-001",
-    variantId: "variant-guinness-stout",
-    sizeMl: 568,
-    serving: "tap",
-    priceCents: 690,
-    locationId: "pogue-mahone",
-  },
-  {
-    id: "offer-002",
-    variantId: "variant-kilkenny-red-ale",
-    sizeMl: 568,
-    serving: "tap",
-    priceCents: 660,
-    locationId: "pogue-mahone",
-  },
-  {
-    id: "offer-003",
-    variantId: "variant-becks-pils",
-    sizeMl: 500,
-    serving: "bottle",
-    priceCents: 420,
-    locationId: "hafenkante-bar",
-  },
-  {
-    id: "offer-004",
-    variantId: "variant-astra-pils",
-    sizeMl: 330,
-    serving: "can",
-    priceCents: 270,
-    locationId: "hafenkante-bar",
-  },
-  {
-    id: "offer-005",
-    variantId: "variant-flensburger-pils",
-    sizeMl: 400,
-    serving: "tap",
-    priceCents: 520,
-    locationId: "foerde-brauhaus",
-  },
-  {
-    id: "offer-006",
-    variantId: "variant-erdinger-hefeweizen",
-    sizeMl: 500,
-    serving: "bottle",
-    priceCents: 540,
-    locationId: "foerde-brauhaus",
-  },
-  {
-    id: "offer-007",
-    variantId: "variant-holsten-pils",
-    sizeMl: 500,
-    serving: "can",
-    priceCents: 139,
-    locationId: "marktfrisch-kiel",
-  },
-  {
-    id: "offer-008",
-    variantId: "variant-guinness-stout",
-    sizeMl: 440,
-    serving: "can",
-    priceCents: 229,
-    locationId: "marktfrisch-kiel",
-  },
-] as const;
+// ---------------------------------------------------------------------------
+// Offer generation helpers
+// ---------------------------------------------------------------------------
+
+type Serving = "tap" | "bottle" | "can";
+
+interface OfferSpec {
+  id: string;
+  variantId: string;
+  sizeMl: number;
+  serving: Serving;
+  priceCents: number;
+  locationId: string;
+}
+
+// Base prices per variant (in cents) for reference — actual price varies by location type and serving
+const basePriceCentsMap: Record<string, number> = {
+  "variant-becks-pils": 390,
+  "variant-becks-gold": 370,
+  "variant-astra-pils": 360,
+  "variant-astra-urtyp": 350,
+  "variant-flensburger-pils": 400,
+  "variant-flensburger-weizen": 430,
+  "variant-holsten-pils": 350,
+  "variant-holsten-export": 360,
+  "variant-jever-pils": 420,
+  "variant-jever-fun": 380,
+  "variant-erdinger-hefeweizen": 480,
+  "variant-erdinger-dunkel": 490,
+  "variant-paulaner-hefeweizen": 490,
+  "variant-paulaner-maerzen": 500,
+  "variant-paulaner-dunkel": 510,
+  "variant-weihenstephaner-hefeweizen": 520,
+  "variant-weihenstephaner-pils": 490,
+  "variant-warsteiner-pils": 380,
+  "variant-bitburger-pils": 390,
+  "variant-krombacher-pils": 385,
+  "variant-krombacher-weizen": 410,
+  "variant-veltins-pils": 395,
+  "variant-radeberger-pils": 400,
+  "variant-augustiner-lager": 460,
+  "variant-augustiner-hefeweizen": 470,
+  "variant-spaten-maerzen": 480,
+  "variant-spaten-lager": 460,
+  "variant-hacker-pschorr-hefeweizen": 510,
+  "variant-hacker-pschorr-dunkel": 520,
+  "variant-oettinger-pils": 280,
+  "variant-oettinger-weizen": 290,
+  "variant-koenigsbacher-pils": 370,
+  "variant-reissdorf-koelsch": 440,
+  "variant-guinness-stout": 620,
+  "variant-kilkenny-red-ale": 600,
+  "variant-murphys-stout": 590,
+  "variant-murphys-red": 580,
+  "variant-heineken-lager": 410,
+  "variant-stella-lager": 420,
+  "variant-corona-extra": 430,
+};
+
+// Multipliers by location type (pubs/bars/restaurants mark up more)
+const locationTypeMultiplier: Record<string, number> = {
+  pub: 1.65,
+  bar: 1.55,
+  restaurant: 1.7,
+  supermarket: 1.0,
+};
+
+// Sizes available per serving type
+const tapSizes = [300, 400, 500];
+const bottleSizes = [330, 500];
+const canSizes = [330, 500];
+
+// Which serving types each location type typically offers
+const locationServingMatrix: Record<string, Serving[]> = {
+  pub: ["tap", "bottle"],
+  bar: ["tap", "bottle", "can"],
+  restaurant: ["tap", "bottle"],
+  supermarket: ["bottle", "can"],
+};
+
+function sizesForServing(serving: Serving): number[] {
+  if (serving === "tap") return tapSizes;
+  if (serving === "bottle") return bottleSizes;
+  return canSizes;
+}
+
+// Variant lists per location — defines what each location stocks
+// Pubs lean Irish + local German; bars lean trendy international + local;
+// restaurants lean Bavarian + premium; supermarkets carry almost everything.
+
+const pubVariants = [
+  "variant-guinness-stout",
+  "variant-kilkenny-red-ale",
+  "variant-murphys-stout",
+  "variant-murphys-red",
+  "variant-flensburger-pils",
+  "variant-holsten-pils",
+  "variant-holsten-export",
+  "variant-astra-pils",
+  "variant-astra-urtyp",
+  "variant-becks-pils",
+  "variant-jever-pils",
+  "variant-reissdorf-koelsch",
+  "variant-heineken-lager",
+];
+
+const barVariants = [
+  "variant-heineken-lager",
+  "variant-stella-lager",
+  "variant-corona-extra",
+  "variant-becks-pils",
+  "variant-becks-gold",
+  "variant-astra-pils",
+  "variant-flensburger-pils",
+  "variant-flensburger-weizen",
+  "variant-holsten-pils",
+  "variant-jever-pils",
+  "variant-veltins-pils",
+  "variant-warsteiner-pils",
+  "variant-bitburger-pils",
+  "variant-krombacher-pils",
+  "variant-guinness-stout",
+];
+
+const restaurantVariants = [
+  "variant-paulaner-hefeweizen",
+  "variant-paulaner-maerzen",
+  "variant-paulaner-dunkel",
+  "variant-erdinger-hefeweizen",
+  "variant-erdinger-dunkel",
+  "variant-weihenstephaner-hefeweizen",
+  "variant-weihenstephaner-pils",
+  "variant-augustiner-lager",
+  "variant-augustiner-hefeweizen",
+  "variant-spaten-maerzen",
+  "variant-spaten-lager",
+  "variant-hacker-pschorr-hefeweizen",
+  "variant-hacker-pschorr-dunkel",
+  "variant-bitburger-pils",
+  "variant-flensburger-pils",
+  "variant-radeberger-pils",
+];
+
+const supermarketVariants = [
+  "variant-becks-pils",
+  "variant-becks-gold",
+  "variant-astra-pils",
+  "variant-astra-urtyp",
+  "variant-flensburger-pils",
+  "variant-flensburger-weizen",
+  "variant-holsten-pils",
+  "variant-holsten-export",
+  "variant-jever-pils",
+  "variant-jever-fun",
+  "variant-erdinger-hefeweizen",
+  "variant-erdinger-dunkel",
+  "variant-paulaner-hefeweizen",
+  "variant-paulaner-maerzen",
+  "variant-weihenstephaner-hefeweizen",
+  "variant-warsteiner-pils",
+  "variant-bitburger-pils",
+  "variant-krombacher-pils",
+  "variant-krombacher-weizen",
+  "variant-veltins-pils",
+  "variant-radeberger-pils",
+  "variant-oettinger-pils",
+  "variant-oettinger-weizen",
+  "variant-koenigsbacher-pils",
+  "variant-heineken-lager",
+  "variant-stella-lager",
+  "variant-corona-extra",
+  "variant-guinness-stout",
+];
+
+const variantsByLocationType: Record<string, string[]> = {
+  pub: pubVariants,
+  bar: barVariants,
+  restaurant: restaurantVariants,
+  supermarket: supermarketVariants,
+};
+
+// Per-location overrides: additional variants or size/price tweaks can be added here.
+// Keys are locationIds; values are extra variantIds stocked at that location.
+const extraVariants: Record<string, string[]> = {
+  "pogue-mahone": ["variant-reissdorf-koelsch"],
+  "tap-room-kiel": ["variant-reissdorf-koelsch", "variant-augustiner-lager"],
+  "foerde-brauhaus": ["variant-reissdorf-koelsch"],
+  "brauhaus-am-schloss": ["variant-reissdorf-koelsch"],
+  "kaufland-hassee": ["variant-augustiner-lager", "variant-augustiner-hefeweizen"],
+};
+
+function roundToNearest5(cents: number): number {
+  return Math.round(cents / 5) * 5;
+}
+
+function computePrice(
+  variantId: string,
+  serving: Serving,
+  sizeMl: number,
+  locationType: string,
+): number {
+  const base = basePriceCentsMap[variantId] ?? 400;
+  const mult = locationTypeMultiplier[locationType] ?? 1.0;
+
+  // Normalize to 500 ml equivalent, then scale to actual size
+  const sizeRatio = sizeMl / 500;
+
+  // Tap carries a premium over bottle/can
+  const servingFactor = serving === "tap" ? 1.15 : serving === "can" ? 0.92 : 1.0;
+
+  const raw = base * mult * sizeRatio * servingFactor;
+  return roundToNearest5(raw);
+}
+
+function buildOffers(): OfferSpec[] {
+  const offers: OfferSpec[] = [];
+  const seen = new Set<string>();
+
+  for (const location of locationSeed) {
+    const locType = location.locationType as string;
+    const servings = locationServingMatrix[locType] ?? ["bottle"];
+    const baseVariants = variantsByLocationType[locType] ?? [];
+    const extras = extraVariants[location.id] ?? [];
+    const variants = [...new Set([...baseVariants, ...extras])];
+
+    for (const variantId of variants) {
+      for (const serving of servings) {
+        // Each location stocks one canonical size per serving type per variant
+        const sizes = sizesForServing(serving);
+        // Pick a single canonical size per variant+serving for on-premise; supermarkets get all sizes
+        const selectedSizes = locType === "supermarket" ? sizes : [sizes[sizes.length - 1]];
+
+        for (const sizeMl of selectedSizes) {
+          const uniqueKey = `${location.id}|${variantId}|${sizeMl}|${serving}`;
+          if (seen.has(uniqueKey)) continue;
+          seen.add(uniqueKey);
+
+          const offerIndex = offers.length + 1;
+          const priceCents = computePrice(variantId, serving, sizeMl, locType);
+
+          offers.push({
+            id: `offer-${String(offerIndex).padStart(4, "0")}`,
+            variantId,
+            sizeMl,
+            serving,
+            priceCents,
+            locationId: location.id,
+          });
+        }
+      }
+    }
+  }
+
+  return offers;
+}
 
 const reviewSeed = [
   {
@@ -176,7 +808,39 @@ const reviewSeed = [
     title: "Cheap and practical",
     body: "Great prices, but the selection rotates a lot.",
   },
+  {
+    locationId: "hafenkante-bar",
+    authorEmail: "anna@example.com",
+    rating: 5,
+    title: "Best view in Kiel",
+    body: "The harbour views alone are worth it. Good tap selection too.",
+  },
+  {
+    locationId: "strandbar-schilksee",
+    authorEmail: "lars@example.com",
+    rating: 4,
+    title: "Summery and relaxed",
+    body: "Great spot for a cold one after sailing. Can gets warm though.",
+  },
+  {
+    locationId: "tap-room-kiel",
+    authorEmail: "anna@example.com",
+    rating: 5,
+    title: "Best tap range in the city",
+    body: "They rotate the taps regularly and always have something interesting.",
+  },
+  {
+    locationId: "rewe-altstadt",
+    authorEmail: "lars@example.com",
+    rating: 3,
+    title: "Convenient location",
+    body: "Good everyday range, prices are fair for a city-centre supermarket.",
+  },
 ] as const;
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
 
 async function main() {
   const connectionString = process.env.DATABASE_URL;
@@ -190,6 +854,7 @@ async function main() {
   const prisma = new PrismaClient({ adapter });
 
   try {
+    // Clear all domain data in dependency order
     await prisma.review.deleteMany();
     await prisma.offerPriceHistory.deleteMany();
     await prisma.priceUpdateProposal.deleteMany();
@@ -199,30 +864,17 @@ async function main() {
     await prisma.beerStyle.deleteMany();
     await prisma.location.deleteMany();
 
+    // Seed users for reviews
     const anna = await prisma.user.upsert({
-      where: {
-        email: "anna@example.com",
-      },
-      update: {
-        displayName: "Anna",
-      },
-      create: {
-        email: "anna@example.com",
-        displayName: "Anna",
-      },
+      where: { email: "anna@example.com" },
+      update: { displayName: "Anna" },
+      create: { email: "anna@example.com", displayName: "Anna" },
     });
 
     const lars = await prisma.user.upsert({
-      where: {
-        email: "lars@example.com",
-      },
-      update: {
-        displayName: "Lars",
-      },
-      create: {
-        email: "lars@example.com",
-        displayName: "Lars",
-      },
+      where: { email: "lars@example.com" },
+      update: { displayName: "Lars" },
+      create: { email: "lars@example.com", displayName: "Lars" },
     });
 
     const reviewUserIdByEmail = new Map<string, string>([
@@ -230,6 +882,7 @@ async function main() {
       [lars.email, lars.id],
     ]);
 
+    // Locations
     for (const location of locationSeed) {
       await prisma.location.create({
         data: {
@@ -243,25 +896,19 @@ async function main() {
       });
     }
 
+    // Beer styles
     for (const style of beerStyleSeed) {
-      await prisma.beerStyle.create({
-        data: {
-          id: style.id,
-          name: style.name,
-        },
-      });
+      await prisma.beerStyle.create({ data: { id: style.id, name: style.name } });
     }
 
+    // Beer brands
     for (const brand of beerBrandSeed) {
       await prisma.beerBrand.create({
-        data: {
-          id: brand.id,
-          name: brand.name,
-          status: "approved",
-        },
+        data: { id: brand.id, name: brand.name, status: "approved" },
       });
     }
 
+    // Beer variants
     for (const variant of beerVariantSeed) {
       await prisma.beerVariant.create({
         data: {
@@ -274,15 +921,18 @@ async function main() {
       });
     }
 
-    for (const offer of beerOfferSeed) {
-      const variant = beerVariantSeed.find((candidate) => candidate.id === offer.variantId);
+    // Build and insert offers
+    const offers = buildOffers();
 
+    console.log(`Generating ${offers.length} beer offers…`);
+
+    for (const offer of offers) {
+      const variant = beerVariantSeed.find((v) => v.id === offer.variantId);
       if (!variant) {
-        throw new Error(`Missing variant '${offer.variantId}' for seed offer '${offer.id}'.`);
+        throw new Error(`Missing variant '${offer.variantId}' for offer '${offer.id}'.`);
       }
 
-      const brand = beerBrandSeed.find((candidate) => candidate.id === variant.brandId);
-
+      const brand = beerBrandSeed.find((b) => b.id === variant.brandId);
       if (!brand) {
         throw new Error(`Missing brand '${variant.brandId}' for variant '${variant.id}'.`);
       }
@@ -310,9 +960,9 @@ async function main() {
       });
     }
 
+    // Reviews
     for (const review of reviewSeed) {
       const userId = reviewUserIdByEmail.get(review.authorEmail);
-
       if (!userId) {
         throw new Error(`Missing seed user for email '${review.authorEmail}'.`);
       }
@@ -328,6 +978,11 @@ async function main() {
         },
       });
     }
+
+    console.log(
+      `Seed complete: ${locationSeed.length} locations, ${beerBrandSeed.length} brands, ` +
+        `${beerVariantSeed.length} variants, ${offers.length} offers.`,
+    );
   } finally {
     await prisma.$disconnect();
     await pool.end();

--- a/src/app/api/v1/beers/route.ts
+++ b/src/app/api/v1/beers/route.ts
@@ -1,8 +1,9 @@
 import { Prisma } from "@/generated/prisma/client";
 import { UnauthorizedError, requireAuthUser } from "@/lib/auth";
 import {
+  BEER_OFFERS_PAGE_SIZE,
+  getBeerOffersPage,
   createOfferOrPriceUpdateProposal,
-  getBeerOffers,
   getLocationContributionPermission,
   getVariantContributionPermission,
 } from "@/lib/query";
@@ -14,7 +15,8 @@ function isKnownRequestError(error: unknown): error is Prisma.PrismaClientKnownR
 }
 
 export async function GET(request: Request): Promise<Response> {
-  const parsed = parseBeerQueryParams(new URL(request.url).searchParams);
+  const url = new URL(request.url);
+  const parsed = parseBeerQueryParams(url.searchParams);
 
   if (!parsed.success) {
     return jsonError(
@@ -28,10 +30,15 @@ export async function GET(request: Request): Promise<Response> {
     );
   }
 
-  const offers = await getBeerOffers(parsed.data);
+  const rawPage = url.searchParams.get("page");
+  const page = Math.max(1, parseInt(rawPage ?? "1", 10) || 1);
+
+  const { offers, total } = await getBeerOffersPage(parsed.data, page);
+  const totalPages = Math.ceil(total / BEER_OFFERS_PAGE_SIZE);
+
   return jsonOk({
     filters: parsed.data,
-    count: offers.length,
+    pagination: { page, pageSize: BEER_OFFERS_PAGE_SIZE, total, totalPages },
     offers,
   });
 }

--- a/src/app/filter-panel.module.css
+++ b/src/app/filter-panel.module.css
@@ -1,0 +1,113 @@
+.panel {
+  border: var(--border-heavy);
+  background: var(--surface);
+  box-shadow: var(--shadow-block);
+  padding: 1rem;
+}
+
+.panelHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.8rem;
+}
+
+.panelHeader h2 {
+  font-size: 1.5rem;
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.clearAll {
+  border: var(--border-regular);
+  background: var(--ink);
+  color: #fff;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-decoration: none;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.clearAll:hover {
+  opacity: 0.85;
+}
+
+.groups {
+  display: grid;
+  gap: 1rem;
+}
+
+.group {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.groupLabel {
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  border-bottom: var(--border-regular);
+  padding-bottom: 0.25rem;
+}
+
+.checkList {
+  display: grid;
+  gap: 0.25rem;
+  list-style: none;
+}
+
+.scrollable {
+  max-height: 200px;
+  overflow-y: auto;
+  border: var(--border-regular);
+  padding: 0.35rem 0.45rem;
+  background: #fff;
+}
+
+.checkItem {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.checkInput {
+  accent-color: var(--ink);
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.radioList {
+  display: grid;
+  gap: 0.25rem;
+  list-style: none;
+}
+
+.radioItem {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.radioInput {
+  accent-color: var(--ink);
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.pending {
+  opacity: 0.6;
+  pointer-events: none;
+}

--- a/src/app/filter-panel.tsx
+++ b/src/app/filter-panel.tsx
@@ -119,13 +119,7 @@ export function FilterPanel({ brands, variants, stylesList, sizes, locations }: 
       ? currentBrands.filter((b) => b !== brandId)
       : [...currentBrands, brandId];
 
-    const brandVariantIds = new Set(variants.filter((v) => v.brandId === brandId).map((v) => v.id));
-    const currentVariants = searchParams.getAll("variantId");
-    const nextVariants = isDeselecting
-      ? currentVariants.filter((v) => !brandVariantIds.has(v))
-      : currentVariants;
-
-    const url = buildUrl({ brandId: nextBrands, variantId: nextVariants });
+    const url = buildUrl({ brandId: nextBrands });
     startTransition(() => {
       router.push(url, { scroll: false });
     });

--- a/src/app/filter-panel.tsx
+++ b/src/app/filter-panel.tsx
@@ -45,6 +45,19 @@ export function FilterPanel({ brands, variants, stylesList, sizes, locations }: 
       ? variants.filter((v) => selectedBrands.includes(v.brandId))
       : variants;
 
+  // Merge variants with the same name into a single checkbox entry.
+  const variantGroups: { name: string; ids: string[] }[] = [];
+  const variantGroupIndex = new Map<string, number>();
+  for (const v of visibleVariants) {
+    const existing = variantGroupIndex.get(v.name);
+    if (existing !== undefined) {
+      variantGroups[existing].ids.push(v.id);
+    } else {
+      variantGroupIndex.set(v.name, variantGroups.length);
+      variantGroups.push({ name: v.name, ids: [v.id] });
+    }
+  }
+
   const hasAnyFilter =
     selectedBrands.length > 0 ||
     selectedVariants.length > 0 ||
@@ -82,6 +95,18 @@ export function FilterPanel({ brands, variants, stylesList, sizes, locations }: 
     const current = searchParams.getAll(key);
     const next = current.includes(value) ? current.filter((v) => v !== value) : [...current, value];
     const url = buildUrl({ [key]: next });
+    startTransition(() => {
+      router.push(url, { scroll: false });
+    });
+  }
+
+  function toggleVariantGroup(ids: string[]) {
+    const current = searchParams.getAll("variantId");
+    const anySelected = ids.some((id) => current.includes(id));
+    const next = anySelected
+      ? current.filter((v) => !ids.includes(v))
+      : [...current, ...ids.filter((id) => !current.includes(id))];
+    const url = buildUrl({ variantId: next });
     startTransition(() => {
       router.push(url, { scroll: false });
     });
@@ -180,20 +205,20 @@ export function FilterPanel({ brands, variants, stylesList, sizes, locations }: 
         )}
 
         {/* Variant */}
-        {visibleVariants.length > 0 && (
+        {variantGroups.length > 0 && (
           <div className={styles.group}>
             <p className={styles.groupLabel}>Variant</p>
             <ul className={`${styles.checkList} ${styles.scrollable}`} role="list">
-              {visibleVariants.map((variant) => (
-                <li key={variant.id} className={styles.checkItem}>
+              {variantGroups.map((group) => (
+                <li key={group.name} className={styles.checkItem}>
                   <input
                     type="checkbox"
-                    id={`variant-${variant.id}`}
+                    id={`variant-${group.name}`}
                     className={styles.checkInput}
-                    checked={selectedVariants.includes(variant.id)}
-                    onChange={() => toggle("variantId", variant.id)}
+                    checked={group.ids.some((id) => selectedVariants.includes(id))}
+                    onChange={() => toggleVariantGroup(group.ids)}
                   />
-                  <label htmlFor={`variant-${variant.id}`}>{variant.name}</label>
+                  <label htmlFor={`variant-${group.name}`}>{group.name}</label>
                 </li>
               ))}
             </ul>

--- a/src/app/filter-panel.tsx
+++ b/src/app/filter-panel.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useTransition } from "react";
+import styles from "./filter-panel.module.css";
+
+const SERVING_TYPES = [
+  { value: "tap", label: "On Tap" },
+  { value: "bottle", label: "Bottle" },
+  { value: "can", label: "Can" },
+] as const;
+
+const LOCATION_TYPES = [
+  { value: "pub", label: "Pub" },
+  { value: "bar", label: "Bar" },
+  { value: "restaurant", label: "Restaurant" },
+  { value: "supermarket", label: "Supermarket" },
+] as const;
+
+type Props = {
+  brands: { id: string; name: string }[];
+  variants: { id: string; name: string; brandId: string }[];
+  stylesList: { id: string; name: string }[];
+  sizes: number[];
+  locations: { id: string; name: string }[];
+};
+
+export function FilterPanel({ brands, variants, stylesList, sizes, locations }: Props) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const selectedBrands = searchParams.getAll("brandId");
+  const selectedVariants = searchParams.getAll("variantId");
+  const selectedStyles = searchParams.getAll("styleId");
+  const selectedSizes = searchParams.getAll("sizeMl");
+  const selectedServings = searchParams.getAll("serving");
+  const selectedLocationTypes = searchParams.getAll("locationType");
+  const selectedLocations = searchParams.getAll("locationId");
+  const currentSort = searchParams.get("sort") ?? "price_asc";
+
+  const visibleVariants =
+    selectedBrands.length > 0
+      ? variants.filter((v) => selectedBrands.includes(v.brandId))
+      : variants;
+
+  const hasAnyFilter =
+    selectedBrands.length > 0 ||
+    selectedVariants.length > 0 ||
+    selectedStyles.length > 0 ||
+    selectedSizes.length > 0 ||
+    selectedServings.length > 0 ||
+    selectedLocationTypes.length > 0 ||
+    selectedLocations.length > 0 ||
+    currentSort !== "price_asc";
+
+  function buildUrl(updates: Record<string, string[]>): string {
+    const params = new URLSearchParams();
+
+    // Carry over all existing params, then apply updates
+    const keys = new Set([...Array.from(searchParams.keys()), ...Object.keys(updates)]);
+
+    for (const key of keys) {
+      const updated = updates[key];
+      if (updated !== undefined) {
+        for (const v of updated) {
+          params.append(key, v);
+        }
+      } else {
+        for (const v of searchParams.getAll(key)) {
+          params.append(key, v);
+        }
+      }
+    }
+
+    const qs = params.toString();
+    return qs ? `/?${qs}` : "/";
+  }
+
+  function toggle(key: string, value: string) {
+    const current = searchParams.getAll(key);
+    const next = current.includes(value) ? current.filter((v) => v !== value) : [...current, value];
+    const url = buildUrl({ [key]: next });
+    startTransition(() => {
+      router.push(url, { scroll: false });
+    });
+  }
+
+  function handleBrandToggle(brandId: string) {
+    const currentBrands = searchParams.getAll("brandId");
+    const isDeselecting = currentBrands.includes(brandId);
+    const nextBrands = isDeselecting
+      ? currentBrands.filter((b) => b !== brandId)
+      : [...currentBrands, brandId];
+
+    const brandVariantIds = new Set(variants.filter((v) => v.brandId === brandId).map((v) => v.id));
+    const currentVariants = searchParams.getAll("variantId");
+    const nextVariants = isDeselecting
+      ? currentVariants.filter((v) => !brandVariantIds.has(v))
+      : currentVariants;
+
+    const url = buildUrl({ brandId: nextBrands, variantId: nextVariants });
+    startTransition(() => {
+      router.push(url, { scroll: false });
+    });
+  }
+
+  function setSort(value: string) {
+    const params = new URLSearchParams();
+    for (const [k, v] of searchParams.entries()) {
+      if (k !== "sort") params.append(k, v);
+    }
+    if (value !== "price_asc") {
+      params.set("sort", value);
+    }
+    const qs = params.toString();
+    startTransition(() => {
+      router.push(qs ? `/?${qs}` : "/", { scroll: false });
+    });
+  }
+
+  return (
+    <section
+      className={`${styles.panel}${isPending ? ` ${styles.pending}` : ""}`}
+      aria-labelledby="filter-heading"
+    >
+      <div className={styles.panelHeader}>
+        <h2 id="filter-heading">Filter Offers</h2>
+        {hasAnyFilter && (
+          <Link href="/" className={styles.clearAll}>
+            Clear All
+          </Link>
+        )}
+      </div>
+
+      <div className={styles.groups}>
+        {/* Sort */}
+        <div className={styles.group}>
+          <p className={styles.groupLabel}>Sort By</p>
+          <ul className={styles.radioList} role="list">
+            {[
+              { value: "price_asc", label: "Price: Low to High" },
+              { value: "price_desc", label: "Price: High to Low" },
+            ].map(({ value, label }) => (
+              <li key={value} className={styles.radioItem}>
+                <input
+                  type="radio"
+                  id={`sort-${value}`}
+                  name="sort"
+                  className={styles.radioInput}
+                  checked={currentSort === value}
+                  onChange={() => setSort(value)}
+                />
+                <label htmlFor={`sort-${value}`}>{label}</label>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* Brand */}
+        {brands.length > 0 && (
+          <div className={styles.group}>
+            <p className={styles.groupLabel}>Brand</p>
+            <ul className={`${styles.checkList} ${styles.scrollable}`} role="list">
+              {brands.map((brand) => (
+                <li key={brand.id} className={styles.checkItem}>
+                  <input
+                    type="checkbox"
+                    id={`brand-${brand.id}`}
+                    className={styles.checkInput}
+                    checked={selectedBrands.includes(brand.id)}
+                    onChange={() => handleBrandToggle(brand.id)}
+                  />
+                  <label htmlFor={`brand-${brand.id}`}>{brand.name}</label>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Variant */}
+        {visibleVariants.length > 0 && (
+          <div className={styles.group}>
+            <p className={styles.groupLabel}>Variant</p>
+            <ul className={`${styles.checkList} ${styles.scrollable}`} role="list">
+              {visibleVariants.map((variant) => (
+                <li key={variant.id} className={styles.checkItem}>
+                  <input
+                    type="checkbox"
+                    id={`variant-${variant.id}`}
+                    className={styles.checkInput}
+                    checked={selectedVariants.includes(variant.id)}
+                    onChange={() => toggle("variantId", variant.id)}
+                  />
+                  <label htmlFor={`variant-${variant.id}`}>{variant.name}</label>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Style */}
+        {stylesList.length > 0 && (
+          <div className={styles.group}>
+            <p className={styles.groupLabel}>Style</p>
+            <ul className={styles.checkList} role="list">
+              {stylesList.map((style) => (
+                <li key={style.id} className={styles.checkItem}>
+                  <input
+                    type="checkbox"
+                    id={`style-${style.id}`}
+                    className={styles.checkInput}
+                    checked={selectedStyles.includes(style.id)}
+                    onChange={() => toggle("styleId", style.id)}
+                  />
+                  <label htmlFor={`style-${style.id}`}>{style.name}</label>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Serving */}
+        <div className={styles.group}>
+          <p className={styles.groupLabel}>Serving</p>
+          <ul className={styles.checkList} role="list">
+            {SERVING_TYPES.map(({ value, label }) => (
+              <li key={value} className={styles.checkItem}>
+                <input
+                  type="checkbox"
+                  id={`serving-${value}`}
+                  className={styles.checkInput}
+                  checked={selectedServings.includes(value)}
+                  onChange={() => toggle("serving", value)}
+                />
+                <label htmlFor={`serving-${value}`}>{label}</label>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* Size */}
+        {sizes.length > 0 && (
+          <div className={styles.group}>
+            <p className={styles.groupLabel}>Size (ml)</p>
+            <ul className={styles.checkList} role="list">
+              {sizes.map((size) => (
+                <li key={size} className={styles.checkItem}>
+                  <input
+                    type="checkbox"
+                    id={`size-${size}`}
+                    className={styles.checkInput}
+                    checked={selectedSizes.includes(String(size))}
+                    onChange={() => toggle("sizeMl", String(size))}
+                  />
+                  <label htmlFor={`size-${size}`}>{size} ml</label>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Location Type */}
+        <div className={styles.group}>
+          <p className={styles.groupLabel}>Location Type</p>
+          <ul className={styles.checkList} role="list">
+            {LOCATION_TYPES.map(({ value, label }) => (
+              <li key={value} className={styles.checkItem}>
+                <input
+                  type="checkbox"
+                  id={`loctype-${value}`}
+                  className={styles.checkInput}
+                  checked={selectedLocationTypes.includes(value)}
+                  onChange={() => toggle("locationType", value)}
+                />
+                <label htmlFor={`loctype-${value}`}>{label}</label>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* Location */}
+        {locations.length > 0 && (
+          <div className={styles.group}>
+            <p className={styles.groupLabel}>Location</p>
+            <ul className={`${styles.checkList} ${styles.scrollable}`} role="list">
+              {locations.map((location) => (
+                <li key={location.id} className={styles.checkItem}>
+                  <input
+                    type="checkbox"
+                    id={`location-${location.id}`}
+                    className={styles.checkInput}
+                    checked={selectedLocations.includes(location.id)}
+                    onChange={() => toggle("locationId", location.id)}
+                  />
+                  <label htmlFor={`location-${location.id}`}>{location.name}</label>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/app/filter-panel.tsx
+++ b/src/app/filter-panel.tsx
@@ -71,10 +71,13 @@ export function FilterPanel({ brands, variants, stylesList, sizes, locations }: 
   function buildUrl(updates: Record<string, string[]>): string {
     const params = new URLSearchParams();
 
-    // Carry over all existing params, then apply updates
+    // Carry over all existing params, then apply updates.
+    // Always drop "page" unless it is explicitly included in updates, so any
+    // filter change resets pagination back to page 1.
     const keys = new Set([...Array.from(searchParams.keys()), ...Object.keys(updates)]);
 
     for (const key of keys) {
+      if (key === "page" && !(key in updates)) continue;
       const updated = updates[key];
       if (updated !== undefined) {
         for (const v of updated) {
@@ -128,7 +131,7 @@ export function FilterPanel({ brands, variants, stylesList, sizes, locations }: 
   function setSort(value: string) {
     const params = new URLSearchParams();
     for (const [k, v] of searchParams.entries()) {
-      if (k !== "sort") params.append(k, v);
+      if (k !== "sort" && k !== "page") params.append(k, v);
     }
     if (value !== "price_asc") {
       params.set("sort", value);

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -97,54 +97,6 @@
   text-transform: uppercase;
 }
 
-.filters {
-  display: grid;
-  gap: 0.8rem;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-}
-
-.filters label {
-  display: grid;
-  gap: 0.35rem;
-  font-size: 0.9rem;
-  text-transform: uppercase;
-}
-
-.filters select {
-  border: var(--border-regular);
-  background: #fff;
-  min-height: 2.4rem;
-  padding: 0.35rem 0.45rem;
-}
-
-.actions {
-  display: flex;
-  align-items: center;
-  gap: 0.8rem;
-}
-
-.actions button,
-.resetLink {
-  border: var(--border-regular);
-  min-height: 2.4rem;
-  padding: 0.35rem 0.75rem;
-  font-weight: 700;
-  text-transform: uppercase;
-}
-
-.actions button {
-  background: var(--ink);
-  color: #fff;
-  cursor: pointer;
-}
-
-.resetLink {
-  background: #fff;
-  text-decoration: none;
-  display: inline-flex;
-  align-items: center;
-}
-
 .offerList {
   list-style: none;
   display: grid;
@@ -244,6 +196,50 @@
   color: #7d1200;
   font-weight: 700;
   font-size: 0.85rem;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 0.9rem;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  border: var(--border-regular);
+  background: #fff2c8;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-decoration: none;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.chip:hover {
+  background: #ffe89a;
+}
+
+.chipClear {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  border: var(--border-regular);
+  background: var(--ink);
+  color: #fff;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-decoration: none;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.chipClear:hover {
+  opacity: 0.85;
 }
 
 @media (min-width: 980px) {

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -242,6 +242,47 @@
   opacity: 0.85;
 }
 
+.pagination {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+  padding-top: 0.8rem;
+  border-top: var(--border-regular);
+}
+
+.pageInfo {
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.88rem;
+}
+
+.pageLink {
+  border: var(--border-regular);
+  background: #fff;
+  padding: 0.3rem 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.88rem;
+  text-decoration: none;
+}
+
+.pageLink:hover {
+  background: var(--surface-strong);
+}
+
+.pageLinkDisabled {
+  border: var(--border-regular);
+  background: #fff;
+  padding: 0.3rem 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.88rem;
+  opacity: 0.35;
+  user-select: none;
+}
+
 @media (min-width: 980px) {
   .main {
     grid-template-columns: minmax(270px, 330px) minmax(0, 1fr);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,8 @@ import {
   formatEur,
   getBeerBrands,
   getBeerOffers,
+  getBeerOffersPage,
+  BEER_OFFERS_PAGE_SIZE,
   getBeerStyles,
   getLocationReviewSummaries,
   getBeerVariants,
@@ -149,6 +151,21 @@ function buildActiveChips(
   return chips;
 }
 
+function buildPageUrl(raw: Record<string, SearchValue>, targetPage: number): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(raw)) {
+    if (key === "page") continue;
+    if (Array.isArray(value)) {
+      for (const v of value) params.append(key, v);
+    } else if (value) {
+      params.append(key, value);
+    }
+  }
+  if (targetPage > 1) params.set("page", String(targetPage));
+  const qs = params.toString();
+  return qs ? `/?${qs}` : "/";
+}
+
 export default async function Home({
   searchParams,
 }: {
@@ -158,15 +175,25 @@ export default async function Home({
   const parsedQuery = parseBeerQueryRecord(rawSearchParams);
   const query = parsedQuery.success ? parsedQuery.data : {};
 
-  const [offers, allOffers, locations, authUser, brands, stylesList, variants] = await Promise.all([
-    getBeerOffers(query),
-    getBeerOffers(),
-    getLocations(),
-    getCurrentAuthUser(),
-    getBeerBrands(),
-    getBeerStyles(),
-    getBeerVariants(),
-  ]);
+  const rawPage = rawSearchParams.page;
+  const page = Math.max(
+    1,
+    parseInt(String(Array.isArray(rawPage) ? rawPage[0] : (rawPage ?? "1")), 10) || 1,
+  );
+
+  const [pageResult, allOffers, locations, authUser, brands, stylesList, variants] =
+    await Promise.all([
+      getBeerOffersPage(query, page),
+      getBeerOffers(),
+      getLocations(),
+      getCurrentAuthUser(),
+      getBeerBrands(),
+      getBeerStyles(),
+      getBeerVariants(),
+    ]);
+
+  const { offers, total } = pageResult;
+  const totalPages = Math.ceil(total / BEER_OFFERS_PAGE_SIZE);
 
   const reviewSummaryByLocation = await getLocationReviewSummaries([
     ...new Set(offers.map((offer) => offer.location.id)),
@@ -243,7 +270,7 @@ export default async function Home({
         </Suspense>
 
         <section className={styles.panel} aria-labelledby="results-heading">
-          <h2 id="results-heading">Offers ({offers.length})</h2>
+          <h2 id="results-heading">Offers ({total})</h2>
 
           {!parsedQuery.success && (
             <div className={styles.errorBox} role="alert" aria-live="polite">
@@ -276,83 +303,113 @@ export default async function Home({
               No offers match your current filter set. Try broadening your search.
             </p>
           ) : (
-            <ul className={styles.offerList}>
-              {offers.map((offer, index) => (
-                <li key={offer.id} className={styles.offerItem}>
-                  <article>
-                    <div className={styles.offerHead}>
-                      <h3>
-                        {offer.brand} {offer.variant}
-                      </h3>
-                      <p className={styles.price}>{formatEur(offer.priceEur)}</p>
-                    </div>
+            <>
+              <ul className={styles.offerList}>
+                {offers.map((offer, index) => (
+                  <li key={offer.id} className={styles.offerItem}>
+                    <article>
+                      <div className={styles.offerHead}>
+                        <h3>
+                          {offer.brand} {offer.variant}
+                        </h3>
+                        <p className={styles.price}>{formatEur(offer.priceEur)}</p>
+                      </div>
 
-                    {index === 0 && (
-                      <p className={styles.cheapest}>
-                        {sortDesc
-                          ? "Highest price in current result"
-                          : "Lowest price in current result"}
-                      </p>
-                    )}
+                      {index === 0 && (
+                        <p className={styles.cheapest}>
+                          {sortDesc
+                            ? "Highest price in current result"
+                            : "Lowest price in current result"}
+                        </p>
+                      )}
 
-                    <dl className={styles.meta}>
-                      <div>
-                        <dt>Style</dt>
-                        <dd>{offer.style}</dd>
-                      </div>
-                      <div>
-                        <dt>Size</dt>
-                        <dd>{offer.sizeMl} ml</dd>
-                      </div>
-                      <div>
-                        <dt>Serving</dt>
-                        <dd>{getServingLabel(offer.serving)}</dd>
-                      </div>
-                      <div>
-                        <dt>Location</dt>
-                        <dd>
-                          <Link href={`/locations/${offer.location.id}`}>
-                            {offer.location.name}
-                          </Link>
-                        </dd>
-                      </div>
-                      <div>
-                        <dt>Type</dt>
-                        <dd>{locationTypeLabel(offer.location.locationType)}</dd>
-                      </div>
-                      <div>
-                        <dt>Reviews</dt>
-                        <dd>
-                          {(() => {
-                            const summary = reviewSummaryByLocation.get(offer.location.id);
+                      <dl className={styles.meta}>
+                        <div>
+                          <dt>Style</dt>
+                          <dd>{offer.style}</dd>
+                        </div>
+                        <div>
+                          <dt>Size</dt>
+                          <dd>{offer.sizeMl} ml</dd>
+                        </div>
+                        <div>
+                          <dt>Serving</dt>
+                          <dd>{getServingLabel(offer.serving)}</dd>
+                        </div>
+                        <div>
+                          <dt>Location</dt>
+                          <dd>
+                            <Link href={`/locations/${offer.location.id}`}>
+                              {offer.location.name}
+                            </Link>
+                          </dd>
+                        </div>
+                        <div>
+                          <dt>Type</dt>
+                          <dd>{locationTypeLabel(offer.location.locationType)}</dd>
+                        </div>
+                        <div>
+                          <dt>Reviews</dt>
+                          <dd>
+                            {(() => {
+                              const summary = reviewSummaryByLocation.get(offer.location.id);
 
-                            if (
-                              !summary ||
-                              summary.reviewCount === 0 ||
-                              summary.averageRating === null
-                            ) {
-                              return "No reviews";
-                            }
+                              if (
+                                !summary ||
+                                summary.reviewCount === 0 ||
+                                summary.averageRating === null
+                              ) {
+                                return "No reviews";
+                              }
 
-                            return `${summary.averageRating.toFixed(1)}/5 (${summary.reviewCount})`;
-                          })()}
-                        </dd>
-                      </div>
-                    </dl>
+                              return `${summary.averageRating.toFixed(1)}/5 (${summary.reviewCount})`;
+                            })()}
+                          </dd>
+                        </div>
+                      </dl>
 
-                    {authUser?.role === "admin" && (
-                      <AdminOfferActions
-                        offerId={offer.id}
-                        currentPriceCents={Math.round(offer.priceEur * 100)}
-                        className={styles.adminActions}
-                        buttonClassName={undefined}
-                        errorClassName={styles.adminError}
-                      />
-                    )}
-                  </article>
-                </li>
-              ))}
-            </ul>
+                      {authUser?.role === "admin" && (
+                        <AdminOfferActions
+                          offerId={offer.id}
+                          currentPriceCents={Math.round(offer.priceEur * 100)}
+                          className={styles.adminActions}
+                          buttonClassName={undefined}
+                          errorClassName={styles.adminError}
+                        />
+                      )}
+                    </article>
+                  </li>
+                ))}
+              </ul>
+
+              {totalPages > 1 && (
+                <nav className={styles.pagination} aria-label="Offer pages">
+                  {page > 1 ? (
+                    <Link
+                      href={buildPageUrl(rawSearchParams, page - 1)}
+                      className={styles.pageLink}
+                    >
+                      &larr; Prev
+                    </Link>
+                  ) : (
+                    <span className={styles.pageLinkDisabled}>&larr; Prev</span>
+                  )}
+                  <span className={styles.pageInfo}>
+                    Page {page} of {totalPages}
+                  </span>
+                  {page < totalPages ? (
+                    <Link
+                      href={buildPageUrl(rawSearchParams, page + 1)}
+                      className={styles.pageLink}
+                    >
+                      Next &rarr;
+                    </Link>
+                  ) : (
+                    <span className={styles.pageLinkDisabled}>Next &rarr;</span>
+                  )}
+                </nav>
+              )}
+            </>
           )}
         </section>
       </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import Link from "next/link";
 import { LogoutButton } from "@/components/logout-button";
 import { AdminOfferActions } from "@/components/admin-offer-actions";
@@ -14,19 +15,135 @@ import {
   locationTypeLabel,
 } from "@/lib/query";
 import { parseBeerQueryRecord } from "@/lib/validation";
+import type { BeerBrand, BeerStyle, BeerVariant, Location } from "@/lib/types";
+import { FilterPanel } from "./filter-panel";
 import styles from "./page.module.css";
 
 type SearchValue = string | string[] | undefined;
 
-const LOCATION_TYPES = ["pub", "bar", "restaurant", "supermarket"] as const;
-const SERVING_TYPES = ["tap", "bottle", "can"] as const;
+type RawMap = Record<string, string[]>;
 
-function firstValue(value: SearchValue): string {
-  if (Array.isArray(value)) {
-    return value[0] ?? "";
+function toRawMap(raw: Record<string, SearchValue>): RawMap {
+  const map: RawMap = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (Array.isArray(value)) {
+      const compact = value.filter(Boolean);
+      if (compact.length > 0) map[key] = compact;
+    } else if (value) {
+      map[key] = [value];
+    }
+  }
+  return map;
+}
+
+function rawMapToUrl(map: RawMap): string {
+  const params = new URLSearchParams();
+  for (const [key, values] of Object.entries(map)) {
+    for (const value of values) {
+      params.append(key, value);
+    }
+  }
+  const qs = params.toString();
+  return qs ? `/?${qs}` : "/";
+}
+
+function removeOneValue(map: RawMap, key: string, value: string): RawMap {
+  const next = { ...map };
+  next[key] = (next[key] ?? []).filter((v) => v !== value);
+  if (next[key].length === 0) delete next[key];
+  return next;
+}
+
+type ActiveChip = { label: string; removeUrl: string };
+
+function buildActiveChips(
+  raw: Record<string, SearchValue>,
+  brands: BeerBrand[],
+  stylesList: BeerStyle[],
+  variants: BeerVariant[],
+  locations: Location[],
+): ActiveChip[] {
+  const chips: ActiveChip[] = [];
+  const map = toRawMap(raw);
+
+  // Brand chips — removing a brand also removes its variants
+  for (const brandId of map.brandId ?? []) {
+    const brand = brands.find((b) => b.id === brandId);
+    const brandVariantIds = new Set(variants.filter((v) => v.brandId === brandId).map((v) => v.id));
+    let nextMap = removeOneValue(map, "brandId", brandId);
+    const nextVariants = (nextMap.variantId ?? []).filter((v) => !brandVariantIds.has(v));
+    if (nextVariants.length > 0) {
+      nextMap = { ...nextMap, variantId: nextVariants };
+    } else {
+      delete nextMap.variantId;
+    }
+    chips.push({
+      label: `Brand: ${brand?.name ?? brandId}`,
+      removeUrl: rawMapToUrl(nextMap),
+    });
   }
 
-  return value ?? "";
+  // Variant chips
+  for (const variantId of map.variantId ?? []) {
+    const variant = variants.find((v) => v.id === variantId);
+    chips.push({
+      label: `Variant: ${variant?.name ?? variantId}`,
+      removeUrl: rawMapToUrl(removeOneValue(map, "variantId", variantId)),
+    });
+  }
+
+  // Style chips
+  for (const styleId of map.styleId ?? []) {
+    const style = stylesList.find((s) => s.id === styleId);
+    chips.push({
+      label: `Style: ${style?.name ?? styleId}`,
+      removeUrl: rawMapToUrl(removeOneValue(map, "styleId", styleId)),
+    });
+  }
+
+  // Size chips
+  for (const sizeMl of map.sizeMl ?? []) {
+    chips.push({
+      label: `Size: ${sizeMl} ml`,
+      removeUrl: rawMapToUrl(removeOneValue(map, "sizeMl", sizeMl)),
+    });
+  }
+
+  // Serving chips
+  for (const serving of map.serving ?? []) {
+    chips.push({
+      label: `Serving: ${getServingLabel(serving as "tap" | "bottle" | "can")}`,
+      removeUrl: rawMapToUrl(removeOneValue(map, "serving", serving)),
+    });
+  }
+
+  // Location type chips
+  for (const locationType of map.locationType ?? []) {
+    chips.push({
+      label: `Type: ${locationTypeLabel(locationType as "pub" | "bar" | "restaurant" | "supermarket")}`,
+      removeUrl: rawMapToUrl(removeOneValue(map, "locationType", locationType)),
+    });
+  }
+
+  // Location chips
+  for (const locationId of map.locationId ?? []) {
+    const location = locations.find((l) => l.id === locationId);
+    chips.push({
+      label: `Location: ${location?.name ?? locationId}`,
+      removeUrl: rawMapToUrl(removeOneValue(map, "locationId", locationId)),
+    });
+  }
+
+  // Sort chip — only when not the default
+  const sort = (map.sort ?? [])[0];
+  if (sort && sort !== "price_asc") {
+    chips.push({
+      label: "Sort: Price High to Low",
+      removeUrl: rawMapToUrl(removeOneValue(map, "sort", sort)),
+    });
+  }
+
+  return chips;
 }
 
 export default async function Home({
@@ -45,9 +162,7 @@ export default async function Home({
     getCurrentAuthUser(),
     getBeerBrands(),
     getBeerStyles(),
-    getBeerVariants({
-      brandId: query.brandId,
-    }),
+    getBeerVariants(),
   ]);
 
   const reviewSummaryByLocation = await getLocationReviewSummaries([
@@ -55,6 +170,8 @@ export default async function Home({
   ]);
 
   const sizes = [...new Set(allOffers.map((offer) => offer.sizeMl))].sort((a, b) => a - b);
+  const activeChips = buildActiveChips(rawSearchParams, brands, stylesList, variants, locations);
+  const sortDesc = query.sort === "price_desc";
 
   return (
     <div className={styles.page}>
@@ -106,8 +223,24 @@ export default async function Home({
       </header>
 
       <main className={styles.main}>
-        <section className={styles.panel} aria-labelledby="filter-heading">
-          <h2 id="filter-heading">Filter Offers</h2>
+        <Suspense
+          fallback={
+            <section className={styles.panel} aria-labelledby="filter-heading">
+              <h2 id="filter-heading">Filter Offers</h2>
+            </section>
+          }
+        >
+          <FilterPanel
+            brands={brands.map((b) => ({ id: b.id, name: b.name }))}
+            variants={variants.map((v) => ({ id: v.id, name: v.name, brandId: v.brandId }))}
+            stylesList={stylesList.map((s) => ({ id: s.id, name: s.name }))}
+            sizes={sizes}
+            locations={locations.map((l) => ({ id: l.id, name: l.name }))}
+          />
+        </Suspense>
+
+        <section className={styles.panel} aria-labelledby="results-heading">
+          <h2 id="results-heading">Offers ({offers.length})</h2>
 
           {!parsedQuery.success && (
             <div className={styles.errorBox} role="alert" aria-live="polite">
@@ -120,102 +253,20 @@ export default async function Home({
             </div>
           )}
 
-          <form className={styles.filters} method="get">
-            <label>
-              Brand
-              <select name="brandId" defaultValue={firstValue(rawSearchParams.brandId)}>
-                <option value="">Any</option>
-                {brands.map((brand) => (
-                  <option key={brand.id} value={brand.id}>
-                    {brand.name}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label>
-              Variant
-              <select name="variantId" defaultValue={firstValue(rawSearchParams.variantId)}>
-                <option value="">Any</option>
-                {variants.map((variant) => (
-                  <option key={variant.id} value={variant.id}>
-                    {variant.name}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label>
-              Style
-              <select name="styleId" defaultValue={firstValue(rawSearchParams.styleId)}>
-                <option value="">Any</option>
-                {stylesList.map((style) => (
-                  <option key={style.id} value={style.id}>
-                    {style.name}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label>
-              Size (ml)
-              <select name="sizeMl" defaultValue={firstValue(rawSearchParams.sizeMl)}>
-                <option value="">Any</option>
-                {sizes.map((size) => (
-                  <option key={size} value={size}>
-                    {size} ml
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label>
-              Serving
-              <select name="serving" defaultValue={firstValue(rawSearchParams.serving)}>
-                <option value="">Any</option>
-                {SERVING_TYPES.map((serving) => (
-                  <option key={serving} value={serving}>
-                    {getServingLabel(serving)}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label>
-              Location Type
-              <select name="locationType" defaultValue={firstValue(rawSearchParams.locationType)}>
-                <option value="">Any</option>
-                {LOCATION_TYPES.map((locationType) => (
-                  <option key={locationType} value={locationType}>
-                    {locationTypeLabel(locationType)}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label>
-              Location
-              <select name="locationId" defaultValue={firstValue(rawSearchParams.locationId)}>
-                <option value="">Any</option>
-                {locations.map((location) => (
-                  <option key={location.id} value={location.id}>
-                    {location.name}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <div className={styles.actions}>
-              <button type="submit">Apply Filters</button>
-              <Link href="/" className={styles.resetLink}>
-                Clear
-              </Link>
+          {activeChips.length > 0 && (
+            <div className={styles.chips} aria-label="Active filters">
+              {activeChips.map((chip) => (
+                <Link key={chip.label} href={chip.removeUrl} className={styles.chip}>
+                  {chip.label} <span aria-hidden="true">×</span>
+                </Link>
+              ))}
+              {activeChips.length > 1 && (
+                <Link href="/" className={styles.chipClear}>
+                  Clear all ×
+                </Link>
+              )}
             </div>
-          </form>
-        </section>
-
-        <section className={styles.panel} aria-labelledby="results-heading">
-          <h2 id="results-heading">Offers ({offers.length})</h2>
+          )}
 
           {offers.length === 0 ? (
             <p className={styles.emptyState}>
@@ -234,7 +285,11 @@ export default async function Home({
                     </div>
 
                     {index === 0 && (
-                      <p className={styles.cheapest}>Lowest price in current result</p>
+                      <p className={styles.cheapest}>
+                        {sortDesc
+                          ? "Highest price in current result"
+                          : "Lowest price in current result"}
+                      </p>
                     )}
 
                     <dl className={styles.meta}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -83,12 +83,23 @@ function buildActiveChips(
     });
   }
 
-  // Variant chips
-  for (const variantId of map.variantId ?? []) {
-    const variant = variants.find((v) => v.id === variantId);
+  // Variant chips — group by name so "Pils" (3 IDs) produces one chip, not three
+  const selectedVariantIds = new Set(map.variantId ?? []);
+  const variantChipGroups = new Map<string, string[]>();
+  for (const variant of variants) {
+    if (selectedVariantIds.has(variant.id)) {
+      const existing = variantChipGroups.get(variant.name) ?? [];
+      variantChipGroups.set(variant.name, [...existing, variant.id]);
+    }
+  }
+  for (const [name, ids] of variantChipGroups.entries()) {
+    let nextMap = map;
+    for (const id of ids) {
+      nextMap = removeOneValue(nextMap, "variantId", id);
+    }
     chips.push({
-      label: `Variant: ${variant?.name ?? variantId}`,
-      removeUrl: rawMapToUrl(removeOneValue(map, "variantId", variantId)),
+      label: `Variant: ${name}`,
+      removeUrl: rawMapToUrl(nextMap),
     });
   }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -66,20 +66,12 @@ function buildActiveChips(
   const chips: ActiveChip[] = [];
   const map = toRawMap(raw);
 
-  // Brand chips — removing a brand also removes its variants
+  // Brand chips
   for (const brandId of map.brandId ?? []) {
     const brand = brands.find((b) => b.id === brandId);
-    const brandVariantIds = new Set(variants.filter((v) => v.brandId === brandId).map((v) => v.id));
-    let nextMap = removeOneValue(map, "brandId", brandId);
-    const nextVariants = (nextMap.variantId ?? []).filter((v) => !brandVariantIds.has(v));
-    if (nextVariants.length > 0) {
-      nextMap = { ...nextMap, variantId: nextVariants };
-    } else {
-      delete nextMap.variantId;
-    }
     chips.push({
       label: `Brand: ${brand?.name ?? brandId}`,
-      removeUrl: rawMapToUrl(nextMap),
+      removeUrl: rawMapToUrl(removeOneValue(map, "brandId", brandId)),
     });
   }
 

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -447,22 +447,18 @@ export async function getVariantContributionPermission(
 export async function getBeerOffers(query: BeerQuery = {}): Promise<BeerOfferWithLocation[]> {
   const offers = await db.beerOffer.findMany({
     where: {
-      sizeMl: query.sizeMl,
-      serving: query.serving,
-      locationId: query.locationId,
+      sizeMl: query.sizeMl?.length ? { in: query.sizeMl } : undefined,
+      serving: query.serving?.length ? { in: query.serving } : undefined,
+      locationId: query.locationId?.length ? { in: query.locationId } : undefined,
       status: "approved",
-      location: query.locationType
-        ? {
-            locationType: query.locationType,
-            status: "approved",
-          }
-        : {
-            status: "approved",
-          },
+      location: {
+        locationType: query.locationType?.length ? { in: query.locationType } : undefined,
+        status: "approved",
+      },
       variantRef: {
-        id: query.variantId,
-        brandId: query.brandId,
-        styleId: query.styleId,
+        id: query.variantId?.length ? { in: query.variantId } : undefined,
+        brandId: query.brandId?.length ? { in: query.brandId } : undefined,
+        styleId: query.styleId?.length ? { in: query.styleId } : undefined,
         status: "approved",
         brand: {
           status: "approved",
@@ -470,14 +466,14 @@ export async function getBeerOffers(query: BeerQuery = {}): Promise<BeerOfferWit
       },
     },
     include: offerInclude(),
-    orderBy: [{ priceCents: "asc" }],
+    orderBy: [{ priceCents: query.sort === "price_desc" ? "desc" : "asc" }],
   });
 
   return offers.map(mapOfferWithLocation);
 }
 
 export async function getLocationOffers(locationId: string): Promise<BeerOfferWithLocation[]> {
-  return getBeerOffers({ locationId });
+  return getBeerOffers({ locationId: [locationId] });
 }
 
 export async function getLocationReviewPermission(

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -444,32 +444,56 @@ export async function getVariantContributionPermission(
   return "forbidden";
 }
 
+export const BEER_OFFERS_PAGE_SIZE = 20;
+
+function buildBeerOffersWhere(query: BeerQuery) {
+  return {
+    sizeMl: query.sizeMl?.length ? { in: query.sizeMl } : undefined,
+    serving: query.serving?.length ? { in: query.serving } : undefined,
+    locationId: query.locationId?.length ? { in: query.locationId } : undefined,
+    status: "approved" as const,
+    location: {
+      locationType: query.locationType?.length ? { in: query.locationType } : undefined,
+      status: "approved" as const,
+    },
+    variantRef: {
+      id: query.variantId?.length ? { in: query.variantId } : undefined,
+      brandId: query.brandId?.length ? { in: query.brandId } : undefined,
+      styleId: query.styleId?.length ? { in: query.styleId } : undefined,
+      status: "approved" as const,
+      brand: { status: "approved" as const },
+    },
+  };
+}
+
 export async function getBeerOffers(query: BeerQuery = {}): Promise<BeerOfferWithLocation[]> {
   const offers = await db.beerOffer.findMany({
-    where: {
-      sizeMl: query.sizeMl?.length ? { in: query.sizeMl } : undefined,
-      serving: query.serving?.length ? { in: query.serving } : undefined,
-      locationId: query.locationId?.length ? { in: query.locationId } : undefined,
-      status: "approved",
-      location: {
-        locationType: query.locationType?.length ? { in: query.locationType } : undefined,
-        status: "approved",
-      },
-      variantRef: {
-        id: query.variantId?.length ? { in: query.variantId } : undefined,
-        brandId: query.brandId?.length ? { in: query.brandId } : undefined,
-        styleId: query.styleId?.length ? { in: query.styleId } : undefined,
-        status: "approved",
-        brand: {
-          status: "approved",
-        },
-      },
-    },
+    where: buildBeerOffersWhere(query),
     include: offerInclude(),
     orderBy: [{ priceCents: query.sort === "price_desc" ? "desc" : "asc" }],
   });
 
   return offers.map(mapOfferWithLocation);
+}
+
+export async function getBeerOffersPage(
+  query: BeerQuery,
+  page: number,
+): Promise<{ offers: BeerOfferWithLocation[]; total: number }> {
+  const where = buildBeerOffersWhere(query);
+
+  const [total, rows] = await Promise.all([
+    db.beerOffer.count({ where }),
+    db.beerOffer.findMany({
+      where,
+      include: offerInclude(),
+      orderBy: [{ priceCents: query.sort === "price_desc" ? "desc" : "asc" }],
+      skip: (page - 1) * BEER_OFFERS_PAGE_SIZE,
+      take: BEER_OFFERS_PAGE_SIZE,
+    }),
+  ]);
+
+  return { offers: rows.map(mapOfferWithLocation), total };
 }
 
 export async function getLocationOffers(locationId: string): Promise<BeerOfferWithLocation[]> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -138,14 +138,17 @@ export type LocationReviewSummary = {
   averageRating: number | null;
 };
 
+export type BeerSort = "price_asc" | "price_desc";
+
 export type BeerQuery = {
-  brandId?: string;
-  variantId?: string;
-  styleId?: string;
-  sizeMl?: number;
-  serving?: ServingType;
-  locationType?: LocationType;
-  locationId?: string;
+  brandId?: string[];
+  variantId?: string[];
+  styleId?: string[];
+  sizeMl?: number[];
+  serving?: ServingType[];
+  locationType?: LocationType[];
+  locationId?: string[];
+  sort?: BeerSort;
 };
 
 export type CreateLocationInput = {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -5,15 +5,17 @@ const locationTypes = ["pub", "bar", "restaurant", "supermarket"] as const;
 const moderationStatuses = ["approved", "rejected"] as const;
 const userRoles = ["user", "moderator", "admin"] as const;
 const reviewStatuses = ["approved", "rejected"] as const;
+const sortOrders = ["price_asc", "price_desc"] as const;
 
 export const beerQuerySchema = z.object({
-  brandId: z.string().trim().min(1).max(100).optional(),
-  variantId: z.string().trim().min(1).max(100).optional(),
-  styleId: z.string().trim().min(1).max(100).optional(),
-  sizeMl: z.coerce.number().int().positive().max(2000).optional(),
-  serving: z.enum(servingTypes).optional(),
-  locationType: z.enum(locationTypes).optional(),
-  locationId: z.string().trim().min(1).max(100).optional(),
+  brandId: z.array(z.string().trim().min(1).max(100)).optional(),
+  variantId: z.array(z.string().trim().min(1).max(100)).optional(),
+  styleId: z.array(z.string().trim().min(1).max(100)).optional(),
+  sizeMl: z.array(z.coerce.number().int().positive().max(2000)).optional(),
+  serving: z.array(z.enum(servingTypes)).optional(),
+  locationType: z.array(z.enum(locationTypes)).optional(),
+  locationId: z.array(z.string().trim().min(1).max(100)).optional(),
+  sort: z.enum(sortOrders).optional(),
 });
 
 export const registerBodySchema = z.object({
@@ -99,17 +101,32 @@ function compactString(value: string | undefined): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+function allValues(value: SearchValue): string[] | undefined {
+  const arr = Array.isArray(value) ? value : value !== undefined ? [value] : [];
+  const compact = arr.map((v) => v.trim()).filter((v) => v.length > 0);
+  return compact.length > 0 ? compact : undefined;
+}
+
+function getAllParam(params: URLSearchParams, key: string): string[] | undefined {
+  const values = params
+    .getAll(key)
+    .map((v) => v.trim())
+    .filter((v) => v.length > 0);
+  return values.length > 0 ? values : undefined;
+}
+
 export function parseBeerQueryRecord(
   record: Record<string, SearchValue>,
 ): ReturnType<typeof beerQuerySchema.safeParse> {
   return beerQuerySchema.safeParse({
-    brandId: compactString(firstValue(record.brandId)),
-    variantId: compactString(firstValue(record.variantId)),
-    styleId: compactString(firstValue(record.styleId)),
-    sizeMl: compactString(firstValue(record.sizeMl)),
-    serving: compactString(firstValue(record.serving)),
-    locationType: compactString(firstValue(record.locationType)),
-    locationId: compactString(firstValue(record.locationId)),
+    brandId: allValues(record.brandId),
+    variantId: allValues(record.variantId),
+    styleId: allValues(record.styleId),
+    sizeMl: allValues(record.sizeMl),
+    serving: allValues(record.serving),
+    locationType: allValues(record.locationType),
+    locationId: allValues(record.locationId),
+    sort: compactString(firstValue(record.sort)),
   });
 }
 
@@ -117,13 +134,14 @@ export function parseBeerQueryParams(
   searchParams: URLSearchParams,
 ): ReturnType<typeof beerQuerySchema.safeParse> {
   return beerQuerySchema.safeParse({
-    brandId: compactString(searchParams.get("brandId") ?? undefined),
-    variantId: compactString(searchParams.get("variantId") ?? undefined),
-    styleId: compactString(searchParams.get("styleId") ?? undefined),
-    sizeMl: compactString(searchParams.get("sizeMl") ?? undefined),
-    serving: compactString(searchParams.get("serving") ?? undefined),
-    locationType: compactString(searchParams.get("locationType") ?? undefined),
-    locationId: compactString(searchParams.get("locationId") ?? undefined),
+    brandId: getAllParam(searchParams, "brandId"),
+    variantId: getAllParam(searchParams, "variantId"),
+    styleId: getAllParam(searchParams, "styleId"),
+    sizeMl: getAllParam(searchParams, "sizeMl"),
+    serving: getAllParam(searchParams, "serving"),
+    locationType: getAllParam(searchParams, "locationType"),
+    locationId: getAllParam(searchParams, "locationId"),
+    sort: compactString(searchParams.get("sort") ?? undefined),
   });
 }
 


### PR DESCRIPTION
# Important Changes

- **Multi-select filters**: Converted beer query filters to support multiple selections by changing string fields to arrays (brands, variants, styles, sizes, serving types, location types)
- **Sorting support**: Added sort parameter to enable price-based sorting of results
- **Variant grouping**: Group variants with identical names into single checkbox entries to prevent duplicates; toggling a group selects/deselects all associated IDs
- **Simplified brand logic**: Removed automatic variant filtering when deselecting brands, allowing independent variant selections
- **Query refactoring**: Extracted beer offers where clause into separate `buildBeerOffersWhere` function and added `getBeerOffersPage` for paginated queries
- **Helper functions**: Implemented `getAllParam` helper to properly extract multiple query parameters from URLSearchParams