### PR TITLE
user-ban-password-reset-functionality

### DIFF
--- a/prisma/migrations/20260413142550_add_user_ban_and_password_reset/migration.sql
+++ b/prisma/migrations/20260413142550_add_user_ban_and_password_reset/migration.sql
@@ -1,0 +1,25 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "isBanned" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "PasswordResetToken" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PasswordResetToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PasswordResetToken_tokenHash_key" ON "PasswordResetToken"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "PasswordResetToken_userId_idx" ON "PasswordResetToken"("userId");
+
+-- CreateIndex
+CREATE INDEX "PasswordResetToken_expiresAt_idx" ON "PasswordResetToken"("expiresAt");
+
+-- AddForeignKey
+ALTER TABLE "PasswordResetToken" ADD CONSTRAINT "PasswordResetToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,6 +52,7 @@ model User {
   role          UserRole @default(user)
   passwordHash  String?
   emailVerified Boolean  @default(false)
+  isBanned      Boolean  @default(false)
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 
@@ -63,10 +64,24 @@ model User {
   reviews                   Review[]
   sessions                  Session[]
   emailVerificationTokens   EmailVerificationToken[]
+  passwordResetTokens       PasswordResetToken[]
   moderationAuditLogs       ModerationAuditLog[]     @relation("ModerationAuditLogModerator")
 }
 
 model EmailVerificationToken {
+  id        String   @id @default(cuid())
+  userId    String
+  tokenHash String   @unique
+  expiresAt DateTime
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([expiresAt])
+}
+
+model PasswordResetToken {
   id        String   @id @default(cuid())
   userId    String
   tokenHash String   @unique

--- a/src/app/(auth)/forgot-password/forgot-password-form.tsx
+++ b/src/app/(auth)/forgot-password/forgot-password-form.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { type FormEvent, useState } from "react";
+import { jsonInit, requestApi } from "@/lib/client-api";
+import styles from "../auth.module.css";
+
+export function ForgotPasswordForm() {
+  const [email, setEmail] = useState("");
+  const [pending, setPending] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (pending) {
+      return;
+    }
+
+    setPending(true);
+    setErrorMessage(null);
+
+    const result = await requestApi<null>(
+      "/api/v1/auth/forgot-password",
+      jsonInit("POST", { body: { email } }),
+      "Unable to send reset email. Please try again.",
+    );
+
+    if (!result.ok) {
+      setErrorMessage(result.message);
+      setPending(false);
+      return;
+    }
+
+    setSent(true);
+    setPending(false);
+  }
+
+  if (sent) {
+    return (
+      <p className={styles.notice} role="status">
+        If an account with that email exists, a password reset link has been sent. Please check your
+        inbox. The link expires in 1 hour.
+      </p>
+    );
+  }
+
+  return (
+    <form className={styles.form} onSubmit={handleSubmit}>
+      <label className={styles.field} htmlFor="forgot-email">
+        Email
+        <input
+          id="forgot-email"
+          name="email"
+          type="email"
+          autoComplete="email"
+          required
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+        />
+      </label>
+
+      {errorMessage && (
+        <p className={styles.error} role="alert" aria-live="polite">
+          {errorMessage}
+        </p>
+      )}
+
+      <div className={styles.actions}>
+        <button type="submit" className={styles.button} disabled={pending}>
+          {pending ? "Sending..." : "Send Reset Link"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+import { ForgotPasswordForm } from "./forgot-password-form";
+import styles from "../auth.module.css";
+
+export default function ForgotPasswordPage() {
+  return (
+    <main className={styles.page}>
+      <p>
+        <Link href="/login">Back to Sign In</Link>
+      </p>
+
+      <section className={styles.panel} aria-labelledby="forgot-password-heading">
+        <h1 id="forgot-password-heading">Forgot Password</h1>
+        <p>
+          Enter your email address and we will send you a link to reset your password. The link
+          expires after 1 hour.
+        </p>
+        <ForgotPasswordForm />
+      </section>
+    </main>
+  );
+}

--- a/src/app/(auth)/login/login-form.tsx
+++ b/src/app/(auth)/login/login-form.tsx
@@ -38,6 +38,8 @@ export function LoginForm() {
       if (result.code === "EMAIL_NOT_VERIFIED") {
         setEmailNotVerified(true);
         setErrorMessage("Your email address has not been verified yet.");
+      } else if (result.code === "ACCOUNT_BANNED") {
+        setErrorMessage("This account has been suspended. Please contact support.");
       } else {
         setErrorMessage(result.message);
       }
@@ -132,6 +134,9 @@ export function LoginForm() {
         </button>
         <Link href="/register" className={styles.secondaryLink}>
           Create Account
+        </Link>
+        <Link href="/forgot-password" className={styles.secondaryLink}>
+          Forgot Password?
         </Link>
       </div>
     </form>

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { ResetPasswordForm } from "./reset-password-form";
+import styles from "../auth.module.css";
+
+type Props = {
+  searchParams: Promise<{ token?: string }>;
+};
+
+export default async function ResetPasswordPage({ searchParams }: Props) {
+  const { token } = await searchParams;
+
+  return (
+    <main className={styles.page}>
+      <p>
+        <Link href="/login">Back to Sign In</Link>
+      </p>
+
+      <section className={styles.panel} aria-labelledby="reset-password-heading">
+        <h1 id="reset-password-heading">Set New Password</h1>
+
+        {!token ? (
+          <>
+            <p className={styles.error} role="alert">
+              This password reset link is invalid or missing a token.
+            </p>
+            <p>
+              <Link href="/forgot-password">Request a new reset link</Link>
+            </p>
+          </>
+        ) : (
+          <>
+            <p>Enter your new password below.</p>
+            <ResetPasswordForm token={token} />
+          </>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/src/app/(auth)/reset-password/reset-password-form.tsx
+++ b/src/app/(auth)/reset-password/reset-password-form.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { type FormEvent, useState } from "react";
+import { jsonInit, requestApi } from "@/lib/client-api";
+import styles from "../auth.module.css";
+
+export function ResetPasswordForm({ token }: { token: string }) {
+  const router = useRouter();
+  const [password, setPassword] = useState("");
+  const [pending, setPending] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (pending) {
+      return;
+    }
+
+    setPending(true);
+    setErrorMessage(null);
+
+    const result = await requestApi<null>(
+      "/api/v1/auth/reset-password",
+      jsonInit("POST", { body: { token, password } }),
+      "Unable to reset your password. Please try again.",
+    );
+
+    if (!result.ok) {
+      setErrorMessage(result.message);
+      setPending(false);
+      return;
+    }
+
+    setDone(true);
+    setPending(false);
+
+    // Redirect to login after a short delay so the user can read the success notice.
+    setTimeout(() => {
+      router.push("/login");
+    }, 2500);
+  }
+
+  if (done) {
+    return (
+      <>
+        <p className={styles.notice} role="status">
+          Your password has been reset. Redirecting you to the sign in page...
+        </p>
+        <p>
+          <Link href="/login">Sign in now</Link>
+        </p>
+      </>
+    );
+  }
+
+  return (
+    <form className={styles.form} onSubmit={handleSubmit}>
+      <label className={styles.field} htmlFor="reset-password">
+        New Password
+        <input
+          id="reset-password"
+          name="password"
+          type="password"
+          autoComplete="new-password"
+          required
+          minLength={8}
+          maxLength={128}
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+        />
+      </label>
+
+      {errorMessage && (
+        <p className={styles.error} role="alert" aria-live="polite">
+          {errorMessage}
+        </p>
+      )}
+
+      <div className={styles.actions}>
+        <button type="submit" className={styles.button} disabled={pending}>
+          {pending ? "Resetting..." : "Set New Password"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -34,6 +34,7 @@ export default async function AdminUsersPage() {
           displayName: user.displayName,
           role: user.role,
           emailVerified: user.emailVerified,
+          isBanned: user.isBanned,
           createdAt: user.createdAt.toISOString(),
         }))}
       />

--- a/src/app/admin/users/users-management.tsx
+++ b/src/app/admin/users/users-management.tsx
@@ -15,6 +15,7 @@ type UserForAdmin = {
   displayName: string;
   role: UserRole;
   emailVerified: boolean;
+  isBanned: boolean;
   createdAt: string;
 };
 
@@ -31,9 +32,15 @@ function UserItem({
   onSaveRole,
   onVerifyEmail,
   onResendVerification,
+  onBan,
+  onUnban,
+  onDelete,
   pending,
   verifying,
   resending,
+  banning,
+  unbanning,
+  deleting,
 }: {
   user: UserForAdmin;
   currentAdminId: string;
@@ -42,12 +49,21 @@ function UserItem({
   onSaveRole: () => void;
   onVerifyEmail: () => void;
   onResendVerification: () => void;
+  onBan: () => void;
+  onUnban: () => void;
+  onDelete: () => void;
   pending: boolean;
   verifying: boolean;
   resending: boolean;
+  banning: boolean;
+  unbanning: boolean;
+  deleting: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
   const roleChanged = selectedRole !== user.role;
+  const isSelf = user.id === currentAdminId;
+  const anyPending = pending || verifying || resending || banning || unbanning || deleting;
 
   return (
     <ManagementItem
@@ -56,7 +72,7 @@ function UserItem({
           {user.displayName} <span className={styles.rowEmail}>({user.email})</span>
         </>
       }
-      status={user.role}
+      status={user.isBanned ? "banned" : user.role}
       statusExtra={
         <span className={user.emailVerified ? styles.verifiedChip : styles.unverifiedChip}>
           {user.emailVerified ? "verified" : "unverified"}
@@ -78,6 +94,7 @@ function UserItem({
             <span className={styles.unverifiedChip}>unverified</span>
           )}
         </p>
+        {user.isBanned && <p className={styles.bannedNotice}>This account is banned.</p>}
         <p>Joined: {formatDate(user.createdAt)}</p>
       </div>
 
@@ -87,14 +104,14 @@ function UserItem({
           id={`role-${user.id}`}
           value={selectedRole}
           onChange={(event) => onRoleChange(event.target.value as UserRole)}
-          disabled={pending}
+          disabled={anyPending}
         >
           <option value="user">user</option>
           <option value="moderator">moderator</option>
           <option value="admin">admin</option>
         </select>
 
-        <button type="button" disabled={pending || !roleChanged} onClick={onSaveRole}>
+        <button type="button" disabled={anyPending || !roleChanged} onClick={onSaveRole}>
           {pending ? "Saving..." : "Save Role"}
         </button>
 
@@ -102,7 +119,7 @@ function UserItem({
           <button
             type="button"
             className={styles.verifyButton}
-            disabled={verifying}
+            disabled={anyPending}
             onClick={onVerifyEmail}
           >
             {verifying ? "Verifying..." : "Verify Email"}
@@ -110,13 +127,61 @@ function UserItem({
         )}
 
         {!user.emailVerified && (
-          <button type="button" disabled={resending} onClick={onResendVerification}>
+          <button type="button" disabled={anyPending} onClick={onResendVerification}>
             {resending ? "Sending..." : "Resend Verification Email"}
           </button>
         )}
+
+        {!isSelf && !user.isBanned && (
+          <button type="button" className={styles.banButton} disabled={anyPending} onClick={onBan}>
+            {banning ? "Banning..." : "Ban User"}
+          </button>
+        )}
+
+        {!isSelf && user.isBanned && (
+          <button
+            type="button"
+            className={styles.unbanButton}
+            disabled={anyPending}
+            onClick={onUnban}
+          >
+            {unbanning ? "Unbanning..." : "Unban User"}
+          </button>
+        )}
+
+        {!isSelf && !confirmDelete && (
+          <button
+            type="button"
+            className={styles.deleteButton}
+            disabled={anyPending}
+            onClick={() => setConfirmDelete(true)}
+          >
+            Delete User
+          </button>
+        )}
+
+        {!isSelf && confirmDelete && (
+          <span className={styles.confirmRow}>
+            <span className={styles.confirmLabel}>Permanently delete this account?</span>
+            <button
+              type="button"
+              className={styles.deleteButton}
+              disabled={anyPending}
+              onClick={() => {
+                setConfirmDelete(false);
+                onDelete();
+              }}
+            >
+              {deleting ? "Deleting..." : "Yes, Delete"}
+            </button>
+            <button type="button" disabled={anyPending} onClick={() => setConfirmDelete(false)}>
+              Cancel
+            </button>
+          </span>
+        )}
       </div>
 
-      {user.id === currentAdminId && (
+      {isSelf && (
         <p className={styles.notice}>This is your account. Last-admin protection applies.</p>
       )}
     </ManagementItem>
@@ -131,6 +196,9 @@ export function UsersManagement({ currentAdminId, users }: UsersManagementProps)
   const [pendingUserId, setPendingUserId] = useState<string | null>(null);
   const [verifyingUserId, setVerifyingUserId] = useState<string | null>(null);
   const [resendingUserId, setResendingUserId] = useState<string | null>(null);
+  const [banningUserId, setBanningUserId] = useState<string | null>(null);
+  const [unbanningUserId, setUnbanningUserId] = useState<string | null>(null);
+  const [deletingUserId, setDeletingUserId] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<{ kind: "error" | "success"; message: string } | null>(
     null,
   );
@@ -217,6 +285,42 @@ export function UsersManagement({ currentAdminId, users }: UsersManagementProps)
     });
   }
 
+  async function banUser(userId: string) {
+    await runUserMutation({
+      userId,
+      setPending: setBanningUserId,
+      input: `/api/v1/admin/users/${userId}/ban`,
+      init: { method: "POST" },
+      fallbackMessage: "Unable to ban user.",
+      successMessage: "User banned and signed out.",
+      refresh: true,
+    });
+  }
+
+  async function unbanUser(userId: string) {
+    await runUserMutation({
+      userId,
+      setPending: setUnbanningUserId,
+      input: `/api/v1/admin/users/${userId}/unban`,
+      init: { method: "POST" },
+      fallbackMessage: "Unable to unban user.",
+      successMessage: "User unbanned.",
+      refresh: true,
+    });
+  }
+
+  async function deleteUser(userId: string) {
+    await runUserMutation({
+      userId,
+      setPending: setDeletingUserId,
+      input: `/api/v1/admin/users/${userId}`,
+      init: { method: "DELETE" },
+      fallbackMessage: "Unable to delete user.",
+      successMessage: "User account deleted.",
+      refresh: true,
+    });
+  }
+
   return (
     <section className={styles.panel} aria-labelledby="users-management-heading">
       <h2 id="users-management-heading">Users ({users.length})</h2>
@@ -256,9 +360,15 @@ export function UsersManagement({ currentAdminId, users }: UsersManagementProps)
                 onSaveRole={() => updateRole(user.id)}
                 onVerifyEmail={() => verifyUser(user.id)}
                 onResendVerification={() => resendVerification(user.id)}
+                onBan={() => banUser(user.id)}
+                onUnban={() => unbanUser(user.id)}
+                onDelete={() => deleteUser(user.id)}
                 pending={pendingUserId === user.id}
                 verifying={verifyingUserId === user.id}
                 resending={resendingUserId === user.id}
+                banning={banningUserId === user.id}
+                unbanning={unbanningUserId === user.id}
+                deleting={deletingUserId === user.id}
               />
             ))}
           </ul>

--- a/src/app/admin/users/users-management.tsx
+++ b/src/app/admin/users/users-management.tsx
@@ -74,9 +74,11 @@ function UserItem({
       }
       status={user.isBanned ? "banned" : user.role}
       statusExtra={
-        <span className={user.emailVerified ? styles.verifiedChip : styles.unverifiedChip}>
-          {user.emailVerified ? "verified" : "unverified"}
-        </span>
+        !user.isBanned ? (
+          <span className={user.emailVerified ? styles.verifiedChip : styles.unverifiedChip}>
+            {user.emailVerified ? "verified" : "unverified"}
+          </span>
+        ) : undefined
       }
       expanded={expanded}
       onToggle={() => setExpanded((prev) => !prev)}
@@ -115,7 +117,7 @@ function UserItem({
           {pending ? "Saving..." : "Save Role"}
         </button>
 
-        {!user.emailVerified && (
+        {!user.emailVerified && !user.isBanned && (
           <button
             type="button"
             className={styles.verifyButton}
@@ -126,7 +128,7 @@ function UserItem({
           </button>
         )}
 
-        {!user.emailVerified && (
+        {!user.emailVerified && !user.isBanned && (
           <button type="button" disabled={anyPending} onClick={onResendVerification}>
             {resending ? "Sending..." : "Resend Verification Email"}
           </button>
@@ -188,6 +190,79 @@ function UserItem({
   );
 }
 
+function UserGroup({
+  heading,
+  headingId,
+  users,
+  currentAdminId,
+  selectedRoles,
+  onRoleChange,
+  onSaveRole,
+  onVerifyEmail,
+  onResendVerification,
+  onBan,
+  onUnban,
+  onDelete,
+  pendingUserId,
+  verifyingUserId,
+  resendingUserId,
+  banningUserId,
+  unbanningUserId,
+  deletingUserId,
+}: {
+  heading: string;
+  headingId: string;
+  users: UserForAdmin[];
+  currentAdminId: string;
+  selectedRoles: Record<string, UserRole>;
+  onRoleChange: (userId: string, role: UserRole) => void;
+  onSaveRole: (userId: string) => void;
+  onVerifyEmail: (userId: string) => void;
+  onResendVerification: (userId: string) => void;
+  onBan: (userId: string) => void;
+  onUnban: (userId: string) => void;
+  onDelete: (userId: string) => void;
+  pendingUserId: string | null;
+  verifyingUserId: string | null;
+  resendingUserId: string | null;
+  banningUserId: string | null;
+  unbanningUserId: string | null;
+  deletingUserId: string | null;
+}) {
+  if (users.length === 0) return null;
+
+  return (
+    <div className={styles.group}>
+      <h3 id={headingId} className={styles.groupHeading}>
+        {heading} <span className={styles.groupCount}>({users.length})</span>
+      </h3>
+      <ul className={styles.list} aria-labelledby={headingId}>
+        {users.map((user) => (
+          <UserItem
+            key={user.id}
+            user={user}
+            currentAdminId={currentAdminId}
+            selectedRole={selectedRoles[user.id] ?? user.role}
+            onRoleChange={(role) => onRoleChange(user.id, role)}
+            onSaveRole={() => onSaveRole(user.id)}
+            onVerifyEmail={() => onVerifyEmail(user.id)}
+            onResendVerification={() => onResendVerification(user.id)}
+            onBan={() => onBan(user.id)}
+            onUnban={() => onUnban(user.id)}
+            onDelete={() => onDelete(user.id)}
+            pending={pendingUserId === user.id}
+            verifying={verifyingUserId === user.id}
+            resending={resendingUserId === user.id}
+            banning={banningUserId === user.id}
+            unbanning={unbanningUserId === user.id}
+            deleting={deletingUserId === user.id}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
 export function UsersManagement({ currentAdminId, users }: UsersManagementProps) {
   const router = useRouter();
   const [selectedRoles, setSelectedRoles] = useState<Record<string, UserRole>>(
@@ -233,23 +308,26 @@ export function UsersManagement({ currentAdminId, users }: UsersManagementProps)
     params.setPending(null);
   }
 
-  const filteredUsers = useMemo(() => {
+  const { verifiedUsers, unverifiedUsers, bannedUsers } = useMemo(() => {
     const q = search.toLowerCase();
-    if (!q) return users;
-    return users.filter(
-      (u) =>
-        u.email.toLowerCase().includes(q) ||
-        u.displayName.toLowerCase().includes(q) ||
-        u.role.toLowerCase().includes(q),
-    );
+    const matches = (u: UserForAdmin) =>
+      !q ||
+      u.email.toLowerCase().includes(q) ||
+      u.displayName.toLowerCase().includes(q) ||
+      u.role.toLowerCase().includes(q);
+
+    return {
+      verifiedUsers: users.filter((u) => !u.isBanned && u.emailVerified && matches(u)),
+      unverifiedUsers: users.filter((u) => !u.isBanned && !u.emailVerified && matches(u)),
+      bannedUsers: users.filter((u) => u.isBanned && matches(u)),
+    };
   }, [users, search]);
+
+  const totalFiltered = verifiedUsers.length + unverifiedUsers.length + bannedUsers.length;
 
   async function updateRole(userId: string) {
     const role = selectedRoles[userId];
-
-    if (!role) {
-      return;
-    }
+    if (!role) return;
 
     await runUserMutation({
       userId,
@@ -321,6 +399,25 @@ export function UsersManagement({ currentAdminId, users }: UsersManagementProps)
     });
   }
 
+  const groupProps = {
+    currentAdminId,
+    selectedRoles,
+    onRoleChange: (userId: string, role: UserRole) =>
+      setSelectedRoles((current) => ({ ...current, [userId]: role })),
+    onSaveRole: updateRole,
+    onVerifyEmail: verifyUser,
+    onResendVerification: resendVerification,
+    onBan: banUser,
+    onUnban: unbanUser,
+    onDelete: deleteUser,
+    pendingUserId,
+    verifyingUserId,
+    resendingUserId,
+    banningUserId,
+    unbanningUserId,
+    deletingUserId,
+  };
+
   return (
     <section className={styles.panel} aria-labelledby="users-management-heading">
       <h2 id="users-management-heading">Users ({users.length})</h2>
@@ -344,34 +441,29 @@ export function UsersManagement({ currentAdminId, users }: UsersManagementProps)
           />
         </div>
 
-        {filteredUsers.length === 0 ? (
+        {totalFiltered === 0 ? (
           <p className={styles.empty}>No users found matching your search.</p>
         ) : (
-          <ul className={styles.list}>
-            {filteredUsers.map((user) => (
-              <UserItem
-                key={user.id}
-                user={user}
-                currentAdminId={currentAdminId}
-                selectedRole={selectedRoles[user.id] ?? user.role}
-                onRoleChange={(role) =>
-                  setSelectedRoles((current) => ({ ...current, [user.id]: role }))
-                }
-                onSaveRole={() => updateRole(user.id)}
-                onVerifyEmail={() => verifyUser(user.id)}
-                onResendVerification={() => resendVerification(user.id)}
-                onBan={() => banUser(user.id)}
-                onUnban={() => unbanUser(user.id)}
-                onDelete={() => deleteUser(user.id)}
-                pending={pendingUserId === user.id}
-                verifying={verifyingUserId === user.id}
-                resending={resendingUserId === user.id}
-                banning={banningUserId === user.id}
-                unbanning={unbanningUserId === user.id}
-                deleting={deletingUserId === user.id}
-              />
-            ))}
-          </ul>
+          <>
+            <UserGroup
+              heading="Verified"
+              headingId="group-verified"
+              users={verifiedUsers}
+              {...groupProps}
+            />
+            <UserGroup
+              heading="Unverified"
+              headingId="group-unverified"
+              users={unverifiedUsers}
+              {...groupProps}
+            />
+            <UserGroup
+              heading="Banned"
+              headingId="group-banned"
+              users={bannedUsers}
+              {...groupProps}
+            />
+          </>
         )}
       </div>
     </section>

--- a/src/app/admin/users/users.module.css
+++ b/src/app/admin/users/users.module.css
@@ -61,6 +61,41 @@
   background: #1a5c1a !important;
 }
 
+.banButton {
+  background: #7a3600 !important;
+  color: #fff !important;
+}
+
+.unbanButton {
+  background: #1a5c1a !important;
+  color: #fff !important;
+}
+
+.deleteButton {
+  background: #5e0f00 !important;
+  color: #fff !important;
+}
+
+.confirmRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.confirmLabel {
+  font-weight: 700;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+}
+
+.bannedNotice {
+  font-weight: 700;
+  color: #5e0f00;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+}
+
 .verified {
   color: #0a4a09;
   font-weight: 700;

--- a/src/app/admin/users/users.module.css
+++ b/src/app/admin/users/users.module.css
@@ -42,6 +42,27 @@
   composes: controls from "../shared-management.module.css";
 }
 
+.group {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.groupHeading {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.4rem 0.6rem;
+  border-left: 4px solid var(--ink);
+  background: var(--surface);
+  margin: 0;
+}
+
+.groupCount {
+  font-weight: 400;
+  opacity: 0.7;
+}
+
 .meta {
   display: grid;
   gap: 0.2rem;

--- a/src/app/api/v1/admin/users/[userId]/ban/route.ts
+++ b/src/app/api/v1/admin/users/[userId]/ban/route.ts
@@ -1,0 +1,42 @@
+import { jsonError, jsonOk } from "@/lib/http";
+import { banUserByAdmin, logModerationAction } from "@/lib/query";
+import { withApiAdmin } from "@/lib/route-handlers";
+
+export async function POST(
+  _request: Request,
+  context: { params: Promise<{ userId: string }> },
+): Promise<Response> {
+  return withApiAdmin(async (admin) => {
+    const { userId } = await context.params;
+    const result = await banUserByAdmin({
+      targetUserId: userId,
+      actingAdminId: admin.id,
+    });
+
+    if (result.outcome === "not_found") {
+      return jsonError(404, "USER_NOT_FOUND", `No user found for id '${userId}'.`);
+    }
+
+    if (result.outcome === "cannot_ban_self") {
+      return jsonError(409, "CANNOT_BAN_SELF", "You cannot ban your own account.");
+    }
+
+    if (result.outcome === "already_banned") {
+      return jsonError(409, "ALREADY_BANNED", "This user is already banned.");
+    }
+
+    await logModerationAction({
+      moderatorId: admin.id,
+      moderatorName: admin.displayName,
+      action: "ban",
+      contentType: "user",
+      contentId: userId,
+      details: {
+        email: result.user.email,
+        displayName: result.user.displayName,
+      },
+    });
+
+    return jsonOk({ user: result.user });
+  });
+}

--- a/src/app/api/v1/admin/users/[userId]/route.ts
+++ b/src/app/api/v1/admin/users/[userId]/route.ts
@@ -1,0 +1,46 @@
+import { jsonError, jsonOk } from "@/lib/http";
+import { deleteUserByAdmin, logModerationAction } from "@/lib/query";
+import { withApiAdmin } from "@/lib/route-handlers";
+
+export async function DELETE(
+  _request: Request,
+  context: { params: Promise<{ userId: string }> },
+): Promise<Response> {
+  return withApiAdmin(async (admin) => {
+    const { userId } = await context.params;
+    const result = await deleteUserByAdmin({
+      targetUserId: userId,
+      actingAdminId: admin.id,
+    });
+
+    if (result.outcome === "not_found") {
+      return jsonError(404, "USER_NOT_FOUND", `No user found for id '${userId}'.`);
+    }
+
+    if (result.outcome === "cannot_delete_self") {
+      return jsonError(409, "CANNOT_DELETE_SELF", "You cannot delete your own account.");
+    }
+
+    if (result.outcome === "cannot_delete_last_admin") {
+      return jsonError(
+        409,
+        "LAST_ADMIN_PROTECTION",
+        "Cannot delete the last admin account. Assign another admin first.",
+      );
+    }
+
+    await logModerationAction({
+      moderatorId: admin.id,
+      moderatorName: admin.displayName,
+      action: "delete",
+      contentType: "user",
+      contentId: userId,
+      details: {
+        email: result.email,
+        displayName: result.displayName,
+      },
+    });
+
+    return jsonOk({ deleted: true });
+  });
+}

--- a/src/app/api/v1/admin/users/[userId]/unban/route.ts
+++ b/src/app/api/v1/admin/users/[userId]/unban/route.ts
@@ -1,0 +1,35 @@
+import { jsonError, jsonOk } from "@/lib/http";
+import { unbanUserByAdmin, logModerationAction } from "@/lib/query";
+import { withApiAdmin } from "@/lib/route-handlers";
+
+export async function POST(
+  _request: Request,
+  context: { params: Promise<{ userId: string }> },
+): Promise<Response> {
+  return withApiAdmin(async (admin) => {
+    const { userId } = await context.params;
+    const result = await unbanUserByAdmin({ targetUserId: userId });
+
+    if (result.outcome === "not_found") {
+      return jsonError(404, "USER_NOT_FOUND", `No user found for id '${userId}'.`);
+    }
+
+    if (result.outcome === "not_banned") {
+      return jsonError(409, "NOT_BANNED", "This user is not currently banned.");
+    }
+
+    await logModerationAction({
+      moderatorId: admin.id,
+      moderatorName: admin.displayName,
+      action: "unban",
+      contentType: "user",
+      contentId: userId,
+      details: {
+        email: result.user.email,
+        displayName: result.user.displayName,
+      },
+    });
+
+    return jsonOk({ user: result.user });
+  });
+}

--- a/src/app/api/v1/auth/forgot-password/route.ts
+++ b/src/app/api/v1/auth/forgot-password/route.ts
@@ -1,0 +1,26 @@
+import { requestPasswordReset } from "@/lib/auth";
+import { sendPasswordResetEmail } from "@/lib/email";
+import { jsonOk } from "@/lib/http";
+import { parseJsonBody } from "@/lib/route-handlers";
+import { buildPasswordResetUrl } from "@/lib/verification";
+import { forgotPasswordBodySchema } from "@/lib/validation";
+
+export async function POST(request: Request): Promise<Response> {
+  const parsed = await parseJsonBody(request, forgotPasswordBodySchema);
+
+  if (!parsed.ok) {
+    return parsed.response;
+  }
+
+  const result = await requestPasswordReset(parsed.data.email);
+
+  // Always return the same response to prevent email enumeration.
+  if (result.ok) {
+    const resetUrl = buildPasswordResetUrl(request, result.token);
+
+    // Fire-and-forget: do not let email errors surface to the client.
+    sendPasswordResetEmail(parsed.data.email, resetUrl).catch(() => {});
+  }
+
+  return jsonOk({ sent: true });
+}

--- a/src/app/api/v1/auth/login/route.ts
+++ b/src/app/api/v1/auth/login/route.ts
@@ -21,6 +21,10 @@ export async function POST(request: Request): Promise<Response> {
       );
     }
 
+    if (result.reason === "ACCOUNT_BANNED") {
+      return jsonError(403, "ACCOUNT_BANNED", "This account has been suspended.");
+    }
+
     return jsonError(401, "INVALID_CREDENTIALS", "Email or password is incorrect.");
   }
 

--- a/src/app/api/v1/auth/reset-password/route.ts
+++ b/src/app/api/v1/auth/reset-password/route.ts
@@ -1,0 +1,28 @@
+import { resetPassword } from "@/lib/auth";
+import { jsonError, jsonOk } from "@/lib/http";
+import { parseJsonBody } from "@/lib/route-handlers";
+import { resetPasswordBodySchema } from "@/lib/validation";
+
+export async function POST(request: Request): Promise<Response> {
+  const parsed = await parseJsonBody(request, resetPasswordBodySchema);
+
+  if (!parsed.ok) {
+    return parsed.response;
+  }
+
+  const result = await resetPassword(parsed.data.token, parsed.data.password);
+
+  if (!result.ok) {
+    if (result.reason === "expired") {
+      return jsonError(
+        400,
+        "TOKEN_EXPIRED",
+        "This password reset link has expired. Please request a new one.",
+      );
+    }
+
+    return jsonError(400, "TOKEN_INVALID", "This password reset link is invalid or already used.");
+  }
+
+  return jsonOk({ reset: true });
+}

--- a/src/components/site-header-client.tsx
+++ b/src/components/site-header-client.tsx
@@ -21,6 +21,59 @@ export function SiteHeaderClient({ authUser }: Props) {
     <header className={styles.header}>
       <div className={styles.bar}>
         <Link href="/" className={styles.brand} onClick={close}>
+          <svg
+            width="28"
+            height="28"
+            viewBox="0 0 32 32"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path
+              d="M22 14C27 14 30 17 30 21C30 25 27 28 22 28"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+            <rect
+              x="3"
+              y="10"
+              width="19"
+              height="19"
+              rx="1"
+              fill="#FFD46B"
+              stroke="currentColor"
+              strokeWidth="2"
+            />
+            <rect
+              x="2"
+              y="5"
+              width="7"
+              height="7"
+              fill="white"
+              stroke="currentColor"
+              strokeWidth="1.5"
+            />
+            <rect
+              x="9"
+              y="1"
+              width="8"
+              height="11"
+              fill="white"
+              stroke="currentColor"
+              strokeWidth="1.5"
+            />
+            <rect
+              x="17"
+              y="4"
+              width="7"
+              height="8"
+              fill="white"
+              stroke="currentColor"
+              strokeWidth="1.5"
+            />
+          </svg>
           Kiel Beer Index
         </Link>
         <button

--- a/src/components/site-header.module.css
+++ b/src/components/site-header.module.css
@@ -15,6 +15,9 @@
 }
 
 .brand {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
   font-family: var(--font-heading), Impact, sans-serif;
   font-size: 1.3rem;
   font-weight: 700;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -11,6 +11,7 @@ const scrypt = promisify(scryptCallback);
 const SESSION_COOKIE_NAME = "kbi_session";
 const SESSION_DURATION_MS = 7 * 24 * 60 * 60 * 1000;
 const VERIFICATION_TOKEN_DURATION_MS = 24 * 60 * 60 * 1000;
+const PASSWORD_RESET_TOKEN_DURATION_MS = 60 * 60 * 1000; // 1 hour
 
 const authUserSelect = {
   id: true,
@@ -122,7 +123,7 @@ export async function registerUser(input: {
 
 export type AuthenticateResult =
   | { ok: true; user: AuthUser }
-  | { ok: false; reason: "INVALID_CREDENTIALS" | "EMAIL_NOT_VERIFIED" };
+  | { ok: false; reason: "INVALID_CREDENTIALS" | "EMAIL_NOT_VERIFIED" | "ACCOUNT_BANNED" };
 
 export async function authenticateUser(input: {
   email: string;
@@ -139,6 +140,7 @@ export async function authenticateUser(input: {
       role: true,
       passwordHash: true,
       emailVerified: true,
+      isBanned: true,
     },
   });
 
@@ -154,6 +156,10 @@ export async function authenticateUser(input: {
 
   if (!user.emailVerified) {
     return { ok: false, reason: "EMAIL_NOT_VERIFIED" };
+  }
+
+  if (user.isBanned) {
+    return { ok: false, reason: "ACCOUNT_BANNED" };
   }
 
   return {
@@ -418,4 +424,87 @@ export async function requestEmailChange(
   const token = await createEmailVerificationToken(userId);
 
   return { ok: true, token };
+}
+
+/**
+ * Generates a password reset token and stores its hash.
+ * Always returns ok: true to prevent email enumeration — callers must send
+ * the token only when the user actually exists.
+ */
+export async function createPasswordResetToken(userId: string): Promise<string> {
+  const token = randomBytes(32).toString("hex");
+  const tokenHash = createHash("sha256").update(token).digest("hex");
+  const expiresAt = new Date(Date.now() + PASSWORD_RESET_TOKEN_DURATION_MS);
+
+  // Invalidate any existing reset tokens for this user.
+  await db.passwordResetToken.deleteMany({ where: { userId } });
+
+  await db.passwordResetToken.create({
+    data: { userId, tokenHash, expiresAt },
+  });
+
+  return token;
+}
+
+export type RequestPasswordResetResult =
+  | { ok: true; userId: string; token: string }
+  | { ok: false; reason: "USER_NOT_FOUND" };
+
+/** Looks up a user by email and creates a reset token. */
+export async function requestPasswordReset(email: string): Promise<RequestPasswordResetResult> {
+  const normalized = normalizeEmail(email);
+
+  const user = await db.user.findUnique({
+    where: { email: normalized },
+    select: { id: true, emailVerified: true, isBanned: true },
+  });
+
+  // Do not reveal whether an account exists — still return a stable response.
+  // But only create a token for active (verified, non-banned) accounts.
+  if (!user || !user.emailVerified || user.isBanned) {
+    return { ok: false, reason: "USER_NOT_FOUND" };
+  }
+
+  const token = await createPasswordResetToken(user.id);
+
+  return { ok: true, userId: user.id, token };
+}
+
+export type ResetPasswordResult = { ok: true } | { ok: false; reason: "invalid" | "expired" };
+
+/** Validates the reset token and updates the user's password. */
+export async function resetPassword(
+  rawToken: string,
+  newPassword: string,
+): Promise<ResetPasswordResult> {
+  const tokenHash = createHash("sha256").update(rawToken).digest("hex");
+
+  const record = await db.passwordResetToken.findUnique({
+    where: { tokenHash },
+    select: { userId: true, expiresAt: true },
+  });
+
+  if (!record) {
+    return { ok: false, reason: "invalid" };
+  }
+
+  if (record.expiresAt <= new Date()) {
+    await db.passwordResetToken.deleteMany({ where: { tokenHash } });
+    return { ok: false, reason: "expired" };
+  }
+
+  const passwordHash = await hashPassword(newPassword);
+
+  // Update password, delete the reset token, and invalidate all sessions
+  // so any existing logins are signed out.
+  await db.user.update({
+    where: { id: record.userId },
+    data: {
+      passwordHash,
+      sessions: { deleteMany: {} },
+      passwordResetTokens: { deleteMany: {} },
+    },
+  });
+
+  return { ok: true };
 }

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -111,3 +111,54 @@ export async function sendEmailChangeVerificationEmail(
 
   logger.info("Email change verification email sent", { to });
 }
+
+export async function sendPasswordResetEmail(to: string, resetUrl: string): Promise<void> {
+  const subject = "Reset your Kiel Beer Index password";
+  const text = [
+    "You requested a password reset for your Kiel Beer Index account.",
+    "",
+    "Click the link below to choose a new password:",
+    "",
+    resetUrl,
+    "",
+    "This link expires in 1 hour.",
+    "",
+    "If you did not request a password reset, you can safely ignore this email.",
+  ].join("\n");
+
+  const html = `
+<p>You requested a password reset for your <strong>Kiel Beer Index</strong> account.</p>
+<p>Click the link below to choose a new password:</p>
+<p><a href="${resetUrl}">${resetUrl}</a></p>
+<p>This link expires in <strong>1 hour</strong>.</p>
+<p>If you did not request a password reset, you can safely ignore this email.</p>
+`.trim();
+
+  if (!isSmtpConfigured()) {
+    logger.info("Password reset (SMTP not configured — logging link instead)", {
+      to,
+      resetUrl,
+    });
+    return;
+  }
+
+  const transport = createTransport({
+    host: process.env.SMTP_HOST,
+    port: Number(process.env.SMTP_PORT ?? 587),
+    secure: process.env.SMTP_SECURE === "true",
+    auth:
+      process.env.SMTP_USER && process.env.SMTP_PASS
+        ? { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS }
+        : undefined,
+  });
+
+  await transport.sendMail({
+    from: process.env.SMTP_FROM ?? "noreply@kiel-beer-index.de",
+    to,
+    subject,
+    text,
+    html,
+  });
+
+  logger.info("Password reset email sent", { to });
+}

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -1258,6 +1258,7 @@ export async function getUsersForAdmin(): Promise<User[]> {
     role: user.role,
     passwordHash: null,
     emailVerified: user.emailVerified,
+    isBanned: user.isBanned,
     createdAt: user.createdAt,
     updatedAt: user.updatedAt,
   }));
@@ -1304,6 +1305,7 @@ export async function updateUserRoleByAdmin(params: {
       role: updatedUser.role,
       passwordHash: null,
       emailVerified: updatedUser.emailVerified,
+      isBanned: updatedUser.isBanned,
       createdAt: updatedUser.createdAt,
       updatedAt: updatedUser.updatedAt,
     },
@@ -1344,6 +1346,7 @@ export async function verifyUserByAdmin(params: {
       role: updatedUser.role,
       passwordHash: null,
       emailVerified: updatedUser.emailVerified,
+      isBanned: updatedUser.isBanned,
       createdAt: updatedUser.createdAt,
       updatedAt: updatedUser.updatedAt,
     },
@@ -1353,6 +1356,132 @@ export async function verifyUserByAdmin(params: {
 // ---------------------------------------------------------------------------
 // Moderation audit log
 // ---------------------------------------------------------------------------
+
+export async function banUserByAdmin(params: {
+  targetUserId: string;
+  actingAdminId: string;
+}): Promise<
+  | { outcome: "banned"; user: User }
+  | { outcome: "not_found" }
+  | { outcome: "already_banned" }
+  | { outcome: "cannot_ban_self" }
+> {
+  if (params.targetUserId === params.actingAdminId) {
+    return { outcome: "cannot_ban_self" };
+  }
+
+  const targetUser = await db.user.findUnique({
+    where: { id: params.targetUserId },
+  });
+
+  if (!targetUser) {
+    return { outcome: "not_found" };
+  }
+
+  if (targetUser.isBanned) {
+    return { outcome: "already_banned" };
+  }
+
+  // Invalidate all sessions so the user is immediately signed out.
+  const updatedUser = await db.user.update({
+    where: { id: params.targetUserId },
+    data: {
+      isBanned: true,
+      sessions: { deleteMany: {} },
+    },
+  });
+
+  return {
+    outcome: "banned",
+    user: {
+      id: updatedUser.id,
+      email: updatedUser.email,
+      displayName: updatedUser.displayName,
+      role: updatedUser.role,
+      passwordHash: null,
+      emailVerified: updatedUser.emailVerified,
+      isBanned: updatedUser.isBanned,
+      createdAt: updatedUser.createdAt,
+      updatedAt: updatedUser.updatedAt,
+    },
+  };
+}
+
+export async function unbanUserByAdmin(params: {
+  targetUserId: string;
+}): Promise<
+  { outcome: "unbanned"; user: User } | { outcome: "not_found" } | { outcome: "not_banned" }
+> {
+  const targetUser = await db.user.findUnique({
+    where: { id: params.targetUserId },
+  });
+
+  if (!targetUser) {
+    return { outcome: "not_found" };
+  }
+
+  if (!targetUser.isBanned) {
+    return { outcome: "not_banned" };
+  }
+
+  const updatedUser = await db.user.update({
+    where: { id: params.targetUserId },
+    data: { isBanned: false },
+  });
+
+  return {
+    outcome: "unbanned",
+    user: {
+      id: updatedUser.id,
+      email: updatedUser.email,
+      displayName: updatedUser.displayName,
+      role: updatedUser.role,
+      passwordHash: null,
+      emailVerified: updatedUser.emailVerified,
+      isBanned: updatedUser.isBanned,
+      createdAt: updatedUser.createdAt,
+      updatedAt: updatedUser.updatedAt,
+    },
+  };
+}
+
+export async function deleteUserByAdmin(params: {
+  targetUserId: string;
+  actingAdminId: string;
+}): Promise<
+  | { outcome: "deleted"; email: string; displayName: string }
+  | { outcome: "not_found" }
+  | { outcome: "cannot_delete_self" }
+  | { outcome: "cannot_delete_last_admin" }
+> {
+  if (params.targetUserId === params.actingAdminId) {
+    return { outcome: "cannot_delete_self" };
+  }
+
+  const targetUser = await db.user.findUnique({
+    where: { id: params.targetUserId },
+  });
+
+  if (!targetUser) {
+    return { outcome: "not_found" };
+  }
+
+  if (targetUser.role === "admin") {
+    const adminCount = await db.user.count({ where: { role: "admin" } });
+
+    if (adminCount <= 1) {
+      return { outcome: "cannot_delete_last_admin" };
+    }
+  }
+
+  await db.user.delete({ where: { id: params.targetUserId } });
+
+  return {
+    outcome: "deleted",
+    email: targetUser.email,
+    displayName: targetUser.displayName,
+  };
+}
 
 export async function logModerationAction<T extends ModerationContentType>(params: {
   moderatorId: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,6 +19,7 @@ export type User = {
   role: UserRole;
   passwordHash?: string | null;
   emailVerified: boolean;
+  isBanned: boolean;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -227,7 +228,7 @@ export type PendingPriceUpdateProposal = PriceUpdateProposal & {
   submitter: ModerationSubmitter | null;
 };
 
-export type ModerationAction = "approve" | "reject" | "delete" | "edit";
+export type ModerationAction = "approve" | "reject" | "delete" | "edit" | "ban" | "unban";
 
 export type ModerationContentType =
   | "location"
@@ -236,7 +237,8 @@ export type ModerationContentType =
   | "variant"
   | "offer"
   | "price_update"
-  | "review";
+  | "review"
+  | "user";
 
 // Per-content-type audit detail shapes
 export type BrandAuditDetails = {
@@ -298,6 +300,12 @@ export type ReviewAuditDetails = {
   fields?: string[];
 };
 
+export type UserAuditDetails = {
+  email?: string;
+  displayName?: string;
+  role?: string;
+};
+
 export type AuditDetailsMap = {
   brand: BrandAuditDetails;
   style: StyleAuditDetails;
@@ -306,6 +314,7 @@ export type AuditDetailsMap = {
   offer: OfferAuditDetails;
   price_update: PriceUpdateAuditDetails;
   review: ReviewAuditDetails;
+  user: UserAuditDetails;
 };
 
 export type AuditDetails = AuditDetailsMap[ModerationContentType];

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -269,3 +269,17 @@ export const changeEmailBodySchema = z.object({
   newEmail: z.string().trim().email().max(255),
   currentPassword: z.string().min(1).max(128),
 });
+
+export const forgotPasswordBodySchema = z.object({
+  email: z.string().trim().email().max(255),
+});
+
+export const resetPasswordBodySchema = z.object({
+  token: z.string().min(1).max(128),
+  password: z
+    .string()
+    .min(8)
+    .max(128)
+    .regex(/[A-Za-z]/, "Password must include at least one letter.")
+    .regex(/[0-9]/, "Password must include at least one number."),
+});

--- a/src/lib/verification.ts
+++ b/src/lib/verification.ts
@@ -23,3 +23,27 @@ export function buildVerificationUrl(request: Request, token: string): string {
 
   return verificationUrl.toString();
 }
+
+export function buildPasswordResetUrl(request: Request, token: string): string {
+  const appUrl = process.env.APP_URL;
+
+  if (!appUrl) {
+    if (process.env.NODE_ENV === "production") {
+      throw new Error(
+        "[verification] APP_URL must be set in production. " +
+          "Refusing to derive base URL from the request to prevent host header injection.",
+      );
+    }
+    console.warn(
+      "[verification] APP_URL is not set; falling back to request origin. " +
+        "Set APP_URL in production to ensure correct password reset links.",
+    );
+  }
+
+  const baseUrl = appUrl ?? new URL(request.url).origin;
+  const resetUrl = new URL("/reset-password", baseUrl);
+
+  resetUrl.searchParams.set("token", token);
+
+  return resetUrl.toString();
+}


### PR DESCRIPTION
# Important Changes

- Added user ban capability with `isBanned` column to User table
- Created PasswordResetToken table with indexing and foreign key constraints
- Implemented password reset URL builder with secure token handling
- Added account ban check to login flow with user-facing error message
- Created admin endpoint to delete users with moderation logging
- Extended moderation action types to support ban/unban operations and user content type
- Added UserGroup component to organize users by verification and ban status
- Updated email verification UI to hide when user is banned
- Refactored user filtering to separate verified, unverified, and banned users