### PR TITLE
container-image-cleanup-resource-limits

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -56,3 +56,25 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE }}-migrate:latest
             ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE }}-migrate:${{ github.sha }}
+
+      - name: Prune old production images
+        if: ${{ github.ref_name == 'main' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          OWNER_TYPE=$(gh api "repos/${{ github.repository }}" --jq '.owner.type')
+          if [ "$OWNER_TYPE" = "Organization" ]; then
+            PKG_BASE="orgs/${OWNER_LC}/packages/container"
+          else
+            PKG_BASE="users/${OWNER_LC}/packages/container"
+          fi
+
+          for pkg in kiebex kiebex-migrate; do
+            VERSIONS=$(gh api "${PKG_BASE}/${pkg}/versions?per_page=100" 2>/dev/null || echo "[]")
+            DELETE_IDS=$(echo "$VERSIONS" | jq -r '
+              sort_by(.created_at) | reverse | .[10:] | .[].id')
+            for id in $DELETE_IDS; do
+              echo "Pruning ${pkg} version ${id}"
+              gh api "${PKG_BASE}/${pkg}/versions/${id}" --method DELETE || true
+            done
+          done

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -12,6 +12,10 @@ jobs:
     name: Build & Publish Docker Image
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - uses: actions/checkout@v6
 
@@ -69,12 +73,50 @@ jobs:
             PKG_BASE="users/${OWNER_LC}/packages/container"
           fi
 
-          for pkg in kiebex kiebex-migrate; do
-            VERSIONS=$(gh api "${PKG_BASE}/${pkg}/versions?per_page=100" 2>/dev/null || echo "[]")
-            DELETE_IDS=$(echo "$VERSIONS" | jq -r '
-              sort_by(.created_at) | reverse | .[10:] | .[].id')
-            for id in $DELETE_IDS; do
+          for pkg in "${IMAGE}" "${IMAGE}-migrate"; do
+            # Collect all versions via pagination so >100-version repos are handled.
+            ALL_VERSIONS="[]"
+            PAGE=1
+            while true; do
+              if ! BATCH=$(gh api "${PKG_BASE}/${pkg}/versions?per_page=100&page=${PAGE}"); then
+                echo "Warning: failed to fetch versions page ${PAGE} for ${pkg}" >&2
+                break
+              fi
+              COUNT=$(echo "$BATCH" | jq 'length')
+              ALL_VERSIONS=$(echo "$ALL_VERSIONS" | jq --argjson batch "$BATCH" '. + $batch')
+              [ "$COUNT" -lt 100 ] && break
+              PAGE=$((PAGE + 1))
+            done
+
+            # Keep the 10 newest *tagged* versions (manifest lists only).
+            # Untagged versions are platform-specific child manifests produced by
+            # multi-arch builds; mixing them into the count would corrupt the budget
+            # and could leave a kept manifest list with deleted children.
+            TAGGED_DELETE_IDS=$(echo "$ALL_VERSIONS" | jq -r '
+              [ .[] | select(.metadata.container.tags | length > 0) ]
+              | sort_by(.created_at) | reverse | .[10:] | .[].id')
+
+            # Cutoff = created_at of the 11th-newest tagged version (first to be deleted).
+            # Child manifests are always pushed before their parent manifest list, so
+            # children belonging to deleted parents will predate this timestamp while
+            # children of the 10 kept parents will postdate it.
+            CUTOFF=$(echo "$ALL_VERSIONS" | jq -r '
+              [ .[] | select(.metadata.container.tags | length > 0) ]
+              | sort_by(.created_at) | reverse
+              | if length > 10 then .[10].created_at else "" end')
+
+            UNTAGGED_DELETE_IDS=""
+            if [ -n "$CUTOFF" ]; then
+              UNTAGGED_DELETE_IDS=$(echo "$ALL_VERSIONS" | jq -r --arg cutoff "$CUTOFF" '
+                [ .[] | select(.metadata.container.tags | length == 0)
+                       | select(.created_at <= $cutoff) ]
+                | .[].id')
+            fi
+
+            for id in $TAGGED_DELETE_IDS $UNTAGGED_DELETE_IDS; do
               echo "Pruning ${pkg} version ${id}"
-              gh api "${PKG_BASE}/${pkg}/versions/${id}" --method DELETE || true
+              if ! gh api "${PKG_BASE}/${pkg}/versions/${id}" --method DELETE; then
+                echo "Warning: failed to delete ${pkg} version ${id}" >&2
+              fi
             done
           done

--- a/.github/workflows/review-app-teardown.yml
+++ b/.github/workflows/review-app-teardown.yml
@@ -11,9 +11,15 @@ jobs:
     permissions:
       contents: write
       deployments: write
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Set lower case owner name
+        run: echo "OWNER_LC=${OWNER,,}" >> $GITHUB_ENV
+        env:
+          OWNER: "${{ github.repository_owner }}"
 
       - name: Configure git
         run: |
@@ -42,3 +48,27 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Delete PR images from GHCR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          OWNER_TYPE=$(gh api "repos/${{ github.repository }}" --jq '.owner.type')
+          if [ "$OWNER_TYPE" = "Organization" ]; then
+            PKG_BASE="orgs/${OWNER_LC}/packages/container"
+          else
+            PKG_BASE="users/${OWNER_LC}/packages/container"
+          fi
+
+          PR_PREFIX="pr-${{ github.event.number }}"
+
+          for pkg in kiebex kiebex-migrate; do
+            VERSIONS=$(gh api "${PKG_BASE}/${pkg}/versions?per_page=100" 2>/dev/null || echo "[]")
+            IDS=$(echo "$VERSIONS" | jq -r \
+              --arg prefix "${PR_PREFIX}" \
+              '[.[] | select(.metadata.container.tags | map(startswith($prefix + "-") or . == $prefix) | any)] | .[].id')
+            for id in $IDS; do
+              echo "Deleting ${pkg} version ${id} (${PR_PREFIX})"
+              gh api "${PKG_BASE}/${pkg}/versions/${id}" --method DELETE || true
+            done
+          done

--- a/manifests/production/deployment.yml
+++ b/manifests/production/deployment.yml
@@ -29,7 +29,7 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 128Mi
+              memory: 256Mi
             limits:
               cpu: 500m
               memory: 512Mi

--- a/manifests/production/migrate.yml
+++ b/manifests/production/migrate.yml
@@ -28,7 +28,7 @@ spec:
           resources:
             requests:
               cpu: 50m
-              memory: 64Mi
+              memory: 128Mi
             limits:
               cpu: 200m
               memory: 256Mi

--- a/manifests/production/postgres.yml
+++ b/manifests/production/postgres.yml
@@ -40,11 +40,11 @@ spec:
                 name: postgres-secret
           resources:
             requests:
-              cpu: 100m
-              memory: 128Mi
+              cpu: "500m"
+              memory: "1Gi"
             limits:
-              cpu: 500m
-              memory: 512Mi
+              cpu: "2"
+              memory: "2Gi"
           volumeMounts:
             - mountPath: /var/lib/postgresql/data
               name: data

--- a/manifests/review-app/deployment.yml
+++ b/manifests/review-app/deployment.yml
@@ -34,7 +34,7 @@ spec:
           resources:
             requests:
               cpu: 50m
-              memory: 64Mi
+              memory: 128Mi
             limits:
               cpu: 200m
               memory: 256Mi
@@ -50,7 +50,7 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 128Mi
+              memory: 192Mi
             limits:
               cpu: 500m
               memory: 512Mi

--- a/manifests/review-app/postgres.yml
+++ b/manifests/review-app/postgres.yml
@@ -41,10 +41,10 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 128Mi
+              memory: 256Mi
             limits:
               cpu: 500m
-              memory: 512Mi
+              memory: 768Mi
           volumeMounts:
             - mountPath: /var/lib/postgresql/data
               name: data


### PR DESCRIPTION
# Important Changes

- Add automated container image cleanup workflows for GitHub Container Registry
  - Production image pruning to retain only 10 most recent versions
  - PR image deletion when review apps are torn down
  - Support for both organization and user-owned repositories

- Increase resource limits across environments
  - Boost memory requests and limits for PostgreSQL and application containers
  - Apply changes to both review and production environments
  - Update production PostgreSQL resources to string format for Kubernetes consistency