### PR TITLE
refactor: extract URL utilities to shared module

### DIFF
--- a/__tests__/lib/beer-directory-url.test.ts
+++ b/__tests__/lib/beer-directory-url.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  toRawMap,
+  rawMapToUrl,
+  removeOneValue,
+  toggleValue,
+  toggleVariantGroup,
+  setSort,
+  buildPaginationUrl,
+} from "@/lib/beer-directory-url";
+
+describe("toRawMap", () => {
+  it("converts string values to single-element arrays", () => {
+    expect(toRawMap({ sort: "price_desc" })).toEqual({ sort: ["price_desc"] });
+  });
+
+  it("converts string arrays, filtering out empty strings", () => {
+    expect(toRawMap({ brandId: ["b-1", "", "b-2"] })).toEqual({
+      brandId: ["b-1", "b-2"],
+    });
+  });
+
+  it("drops keys whose only values are empty strings", () => {
+    expect(toRawMap({ brandId: ["", ""] })).toEqual({});
+  });
+
+  it("drops undefined values", () => {
+    expect(toRawMap({ brandId: undefined, sort: "price_asc" })).toEqual({
+      sort: ["price_asc"],
+    });
+  });
+});
+
+describe("rawMapToUrl", () => {
+  it("returns / for an empty map", () => {
+    expect(rawMapToUrl({})).toBe("/");
+  });
+
+  it("serializes a single value", () => {
+    expect(rawMapToUrl({ sort: ["price_desc"] })).toBe("/?sort=price_desc");
+  });
+
+  it("serializes multiple values for the same key", () => {
+    const url = rawMapToUrl({ brandId: ["b-1", "b-2"] });
+    expect(url).toBe("/?brandId=b-1&brandId=b-2");
+  });
+});
+
+describe("removeOneValue", () => {
+  it("removes a value that is present", () => {
+    const map = { brandId: ["b-1", "b-2"] };
+    expect(removeOneValue(map, "brandId", "b-1")).toEqual({ brandId: ["b-2"] });
+  });
+
+  it("deletes the key when the last value is removed", () => {
+    const map = { brandId: ["b-1"] };
+    expect(removeOneValue(map, "brandId", "b-1")).toEqual({});
+  });
+
+  it("is a no-op when the value is absent", () => {
+    const map = { brandId: ["b-1"] };
+    expect(removeOneValue(map, "brandId", "b-99")).toEqual({ brandId: ["b-1"] });
+  });
+
+  it("does not drop page (preserves it for chip removal)", () => {
+    const map = { brandId: ["b-1"], page: ["2"] };
+    expect(removeOneValue(map, "brandId", "b-1")).toEqual({ page: ["2"] });
+  });
+});
+
+describe("toggleValue", () => {
+  it("adds a value that is not yet present", () => {
+    const result = toggleValue({ brandId: ["b-1"] }, "brandId", "b-2");
+    expect(result.brandId).toEqual(["b-1", "b-2"]);
+  });
+
+  it("removes a value that is already present", () => {
+    const result = toggleValue({ brandId: ["b-1", "b-2"] }, "brandId", "b-1");
+    expect(result.brandId).toEqual(["b-2"]);
+  });
+
+  it("deletes the key when the last value is toggled off", () => {
+    const result = toggleValue({ brandId: ["b-1"] }, "brandId", "b-1");
+    expect(result.brandId).toBeUndefined();
+  });
+
+  it("drops page on every toggle", () => {
+    const map = { brandId: ["b-1"], page: ["3"] };
+    const result = toggleValue(map, "brandId", "b-2");
+    expect(result.page).toBeUndefined();
+  });
+
+  it("preserves unrelated keys", () => {
+    const map = { sort: ["price_desc"], sizeMl: ["500"] };
+    const result = toggleValue(map, "sizeMl", "330");
+    expect(result.sort).toEqual(["price_desc"]);
+    expect(result.sizeMl).toEqual(["500", "330"]);
+  });
+});
+
+describe("toggleVariantGroup", () => {
+  it("adds all group IDs when none are selected", () => {
+    const result = toggleVariantGroup({ variantId: ["v-other"] }, ["v-1", "v-2"]);
+    expect(result.variantId).toEqual(expect.arrayContaining(["v-other", "v-1", "v-2"]));
+  });
+
+  it("removes all group IDs when any is selected", () => {
+    const result = toggleVariantGroup({ variantId: ["v-1", "v-other"] }, ["v-1", "v-2"]);
+    expect(result.variantId).toEqual(["v-other"]);
+  });
+
+  it("deletes variantId when all IDs are removed", () => {
+    const result = toggleVariantGroup({ variantId: ["v-1"] }, ["v-1"]);
+    expect(result.variantId).toBeUndefined();
+  });
+
+  it("drops page", () => {
+    const map = { variantId: ["v-1"], page: ["2"] };
+    const result = toggleVariantGroup(map, ["v-1"]);
+    expect(result.page).toBeUndefined();
+  });
+});
+
+describe("setSort", () => {
+  it("sets a non-default sort value", () => {
+    const result = setSort({}, "price_desc");
+    expect(result.sort).toEqual(["price_desc"]);
+  });
+
+  it("omits sort key for the default value (price_asc)", () => {
+    const result = setSort({ sort: ["price_desc"] }, "price_asc");
+    expect(result.sort).toBeUndefined();
+  });
+
+  it("replaces an existing sort value", () => {
+    const result = setSort({ sort: ["name_asc"] }, "price_desc");
+    expect(result.sort).toEqual(["price_desc"]);
+  });
+
+  it("drops page", () => {
+    const result = setSort({ page: ["2"] }, "price_desc");
+    expect(result.page).toBeUndefined();
+  });
+
+  it("preserves filter keys", () => {
+    const result = setSort({ brandId: ["b-1"], sort: ["name_asc"] }, "price_desc");
+    expect(result.brandId).toEqual(["b-1"]);
+  });
+});
+
+describe("buildPaginationUrl", () => {
+  it("omits page param on page 1", () => {
+    const url = buildPaginationUrl({ sort: "price_desc" }, 1);
+    expect(url).toBe("/?sort=price_desc");
+    expect(url).not.toContain("page");
+  });
+
+  it("includes page param for pages > 1", () => {
+    const url = buildPaginationUrl({ sort: "price_desc" }, 3);
+    expect(url).toContain("page=3");
+    expect(url).toContain("sort=price_desc");
+  });
+
+  it("replaces an existing page param", () => {
+    const url = buildPaginationUrl({ sort: "price_desc", page: "2" }, 4);
+    expect(url).toContain("page=4");
+    expect(url).not.toMatch(/page=2/);
+  });
+
+  it("returns / for page 1 with no other params", () => {
+    expect(buildPaginationUrl({}, 1)).toBe("/");
+  });
+});

--- a/src/app/filter-panel.module.css
+++ b/src/app/filter-panel.module.css
@@ -210,7 +210,7 @@ details[open] .body {
 }
 
 /* Filled dot when selected */
-.radioItem[aria-checked="true"] .radioIndicator {
+.radioItem.selected .radioIndicator {
   background: var(--ink);
   box-shadow: inset 0 0 0 3px var(--surface);
 }
@@ -218,6 +218,38 @@ details[open] .body {
 /* Stronger text weight for selected state */
 .selected {
   font-weight: 700;
+}
+
+/* Visually hidden but accessible — used to hide the native radio input while
+   keeping it in the accessibility tree for keyboard/AT interaction. */
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Submit button shown only via <noscript> (no-JS fallback for the sort form). */
+.sortSubmit {
+  display: block;
+  margin-top: 0.5rem;
+  border: var(--border-regular);
+  background: var(--ink);
+  color: #fff;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.sortSubmit:hover {
+  opacity: 0.85;
 }
 
 /* Desktop: always show the body, hide the mobile toggle */

--- a/src/app/filter-panel.module.css
+++ b/src/app/filter-panel.module.css
@@ -5,9 +5,21 @@
   padding: 1rem;
 }
 
-/* Mobile toggle button — hidden on desktop */
+/* Strip default <details> / <summary> browser chrome */
+.disclosure {
+  display: block;
+}
+
+.disclosure > summary {
+  list-style: none;
+}
+
+.disclosure > summary::-webkit-details-marker {
+  display: none;
+}
+
+/* Mobile summary / toggle — hidden on desktop */
 .toggle {
-  all: unset;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -17,7 +29,7 @@
   font-weight: 700;
   text-transform: uppercase;
   cursor: pointer;
-  box-sizing: border-box;
+  user-select: none;
   line-height: 1.2;
 }
 
@@ -26,12 +38,16 @@
   outline-offset: 3px;
 }
 
-/* Collapsible body */
+.toggleIcon {
+  font-size: 0.9rem;
+}
+
+/* Collapsible body — hidden on mobile until <details> is open */
 .body {
   display: none;
 }
 
-.bodyOpen {
+details[open] .body {
   display: block;
   margin-top: 0.75rem;
 }
@@ -84,6 +100,8 @@
   padding-bottom: 0.25rem;
 }
 
+/* ── Shared link-item base ── */
+
 .checkList {
   display: grid;
   gap: 0.25rem;
@@ -98,23 +116,60 @@
   background: #fff;
 }
 
+/* Checkbox-style link */
 .checkItem {
   display: flex;
   align-items: center;
   gap: 0.45rem;
   font-size: 0.9rem;
+  text-decoration: none;
+  color: var(--ink);
   cursor: pointer;
   user-select: none;
+  padding: 0.1rem 0;
 }
 
-.checkInput {
-  accent-color: var(--ink);
+.checkItem:hover {
+  text-decoration: underline;
+}
+
+.checkItem:focus-visible {
+  outline: 2px dashed var(--accent);
+  outline-offset: 2px;
+}
+
+/* Faux checkbox square */
+.checkIndicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
   width: 1rem;
   height: 1rem;
-  flex-shrink: 0;
-  cursor: pointer;
+  border: 2px solid var(--ink);
+  background: #fff;
+  position: relative;
 }
 
+/* Checkmark via pseudo-element when selected */
+.checkItem[aria-checked="true"] .checkIndicator {
+  background: var(--ink);
+}
+
+.checkItem[aria-checked="true"] .checkIndicator::after {
+  content: "";
+  position: absolute;
+  left: 2px;
+  top: -1px;
+  width: 5px;
+  height: 8px;
+  border: 2px solid #fff;
+  border-top: none;
+  border-left: none;
+  transform: rotate(45deg);
+}
+
+/* Radio-style link */
 .radioList {
   display: grid;
   gap: 0.25rem;
@@ -126,32 +181,58 @@
   align-items: center;
   gap: 0.45rem;
   font-size: 0.9rem;
+  text-decoration: none;
+  color: var(--ink);
   cursor: pointer;
   user-select: none;
+  padding: 0.1rem 0;
 }
 
-.radioInput {
-  accent-color: var(--ink);
+.radioItem:hover {
+  text-decoration: underline;
+}
+
+.radioItem:focus-visible {
+  outline: 2px dashed var(--accent);
+  outline-offset: 2px;
+}
+
+/* Faux radio circle */
+.radioIndicator {
+  display: inline-block;
+  flex-shrink: 0;
   width: 1rem;
   height: 1rem;
-  flex-shrink: 0;
-  cursor: pointer;
+  border-radius: 50%;
+  border: 2px solid var(--ink);
+  background: #fff;
+  box-sizing: border-box;
 }
 
-.pending {
-  opacity: 0.6;
-  pointer-events: none;
+/* Filled dot when selected */
+.radioItem[aria-checked="true"] .radioIndicator {
+  background: var(--ink);
+  box-shadow: inset 0 0 0 3px var(--surface);
 }
 
-/* Desktop: always show body, hide toggle button */
+/* Stronger text weight for selected state */
+.selected {
+  font-weight: 700;
+}
+
+/* Desktop: always show the body, hide the mobile toggle */
 @media (min-width: 980px) {
   .toggle {
     display: none;
   }
 
-  .body,
-  .bodyOpen {
+  .body {
     display: block;
+    margin-top: 0;
+  }
+
+  /* Override the details[open] rule — body is always visible on desktop */
+  details[open] .body {
     margin-top: 0;
   }
 

--- a/src/app/filter-panel.tsx
+++ b/src/app/filter-panel.tsx
@@ -6,7 +6,6 @@ import {
   rawMapToUrl,
   toggleValue,
   toggleVariantGroup,
-  setSort,
 } from "@/lib/beer-directory-url";
 import styles from "./filter-panel.module.css";
 
@@ -98,33 +97,69 @@ export function FilterPanel({ brands, variants, stylesList, sizes, locations, se
             {/* ── Sort ── */}
             <div className={styles.group}>
               <p className={styles.groupLabel} id="sort-group-label">Sort By</p>
-              <ul
-                className={styles.radioList}
-                role="radiogroup"
+              {/*
+               * Native <form method="GET"> + <input type="radio"> restores correct keyboard
+               * semantics (arrow-key navigation, spacebar selection) that <a role="radio">
+               * cannot provide.  Hidden inputs preserve all active filters; the sort radio
+               * replaces only the sort param.  An inline script auto-submits on change so
+               * JS users get immediate navigation; the <noscript> button covers the no-JS path.
+               */}
+              <form
+                id="sort-form"
+                method="GET"
+                action="/"
                 aria-labelledby="sort-group-label"
               >
-                {[
-                  { value: "price_asc", label: "Price: Low to High" },
-                  { value: "price_desc", label: "Price: High to Low" },
-                  { value: "name_asc", label: "Brand: A to Z" },
-                  { value: "name_desc", label: "Brand: Z to A" },
-                ].map(({ value, label }) => {
-                  const checked = currentSort === value;
-                  return (
-                    <li key={value} role="presentation">
-                      <Link
-                        href={rawMapToUrl(setSort(map, value))}
-                        role="radio"
-                        aria-checked={checked}
-                        className={`${styles.radioItem}${checked ? ` ${styles.selected}` : ""}`}
-                      >
-                        <span className={styles.radioIndicator} aria-hidden="true" />
-                        {label}
-                      </Link>
-                    </li>
-                  );
-                })}
-              </ul>
+                {Object.entries(map)
+                  .filter(([k]) => k !== "sort" && k !== "page")
+                  .flatMap(([k, vs]) =>
+                    vs.map((v, i) => (
+                      <input key={`${k}-${i}`} type="hidden" name={k} value={v} />
+                    )),
+                  )}
+                <ul className={styles.radioList} role="group" aria-labelledby="sort-group-label">
+                  {[
+                    { value: "price_asc", label: "Price: Low to High" },
+                    { value: "price_desc", label: "Price: High to Low" },
+                    { value: "name_asc", label: "Brand: A to Z" },
+                    { value: "name_desc", label: "Brand: Z to A" },
+                  ].map(({ value, label }) => {
+                    const checked = currentSort === value;
+                    const id = `sort-${value}`;
+                    return (
+                      <li key={value}>
+                        <label
+                          htmlFor={id}
+                          className={`${styles.radioItem}${checked ? ` ${styles.selected}` : ""}`}
+                        >
+                          <input
+                            type="radio"
+                            id={id}
+                            name="sort"
+                            value={value}
+                            defaultChecked={checked}
+                            className={styles.srOnly}
+                          />
+                          <span className={styles.radioIndicator} aria-hidden="true" />
+                          {label}
+                        </label>
+                      </li>
+                    );
+                  })}
+                </ul>
+                <noscript>
+                  <button type="submit" className={styles.sortSubmit}>
+                    Apply sort
+                  </button>
+                </noscript>
+              </form>
+              {/* Auto-submit the form immediately on radio change when JS is available. */}
+              <script
+                dangerouslySetInnerHTML={{
+                  __html:
+                    "var _sf=document.getElementById('sort-form');if(_sf)_sf.addEventListener('change',function(){_sf.submit();});",
+                }}
+              />
             </div>
 
             {/* ── Brand ── */}

--- a/src/app/filter-panel.tsx
+++ b/src/app/filter-panel.tsx
@@ -1,9 +1,13 @@
-"use client";
-
 import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
-import { useState, useTransition } from "react";
 import { LOCATION_TYPE_OPTIONS, SERVING_TYPE_OPTIONS } from "@/lib/display";
+import {
+  type SearchValue,
+  toRawMap,
+  rawMapToUrl,
+  toggleValue,
+  toggleVariantGroup,
+  setSort,
+} from "@/lib/beer-directory-url";
 import styles from "./filter-panel.module.css";
 
 type Props = {
@@ -12,28 +16,28 @@ type Props = {
   stylesList: { id: string; name: string }[];
   sizes: number[];
   locations: { id: string; name: string }[];
+  searchParams: Record<string, SearchValue>;
 };
 
-export function FilterPanel({ brands, variants, stylesList, sizes, locations }: Props) {
-  const searchParams = useSearchParams();
-  const router = useRouter();
-  const [isPending, startTransition] = useTransition();
+export function FilterPanel({ brands, variants, stylesList, sizes, locations, searchParams }: Props) {
+  const map = toRawMap(searchParams);
 
-  const selectedBrands = searchParams.getAll("brandId");
-  const selectedVariants = searchParams.getAll("variantId");
-  const selectedStyles = searchParams.getAll("styleId");
-  const selectedSizes = searchParams.getAll("sizeMl");
-  const selectedServings = searchParams.getAll("serving");
-  const selectedLocationTypes = searchParams.getAll("locationType");
-  const selectedLocations = searchParams.getAll("locationId");
-  const currentSort = searchParams.get("sort") ?? "price_asc";
+  const selectedBrands = map.brandId ?? [];
+  const selectedVariants = map.variantId ?? [];
+  const selectedStyles = map.styleId ?? [];
+  const selectedSizes = map.sizeMl ?? [];
+  const selectedServings = map.serving ?? [];
+  const selectedLocationTypes = map.locationType ?? [];
+  const selectedLocations = map.locationId ?? [];
+  const currentSort = (map.sort ?? ["price_asc"])[0];
 
+  // Only show variants for selected brands (or all if no brand filter is active).
   const visibleVariants =
     selectedBrands.length > 0
       ? variants.filter((v) => selectedBrands.includes(v.brandId))
       : variants;
 
-  // Merge variants with the same name into a single checkbox entry.
+  // Merge variants with the same display name into a single toggle entry.
   const variantGroups: { name: string; ids: string[] }[] = [];
   const variantGroupIndex = new Map<string, number>();
   for (const v of visibleVariants) {
@@ -67,279 +71,235 @@ export function FilterPanel({ brands, variants, stylesList, sizes, locations }: 
     currentSort !== "price_asc",
   ].filter(Boolean).length;
 
-  const [isOpen, setIsOpen] = useState(false);
-
-  function buildUrl(updates: Record<string, string[]>): string {
-    const params = new URLSearchParams();
-
-    // Carry over all existing params, then apply updates.
-    // Always drop "page" unless it is explicitly included in updates, so any
-    // filter change resets pagination back to page 1.
-    const keys = new Set([...Array.from(searchParams.keys()), ...Object.keys(updates)]);
-
-    for (const key of keys) {
-      if (key === "page" && !(key in updates)) continue;
-      const updated = updates[key];
-      if (updated !== undefined) {
-        for (const v of updated) {
-          params.append(key, v);
-        }
-      } else {
-        for (const v of searchParams.getAll(key)) {
-          params.append(key, v);
-        }
-      }
-    }
-
-    const qs = params.toString();
-    return qs ? `/?${qs}` : "/";
-  }
-
-  function toggle(key: string, value: string) {
-    const current = searchParams.getAll(key);
-    const next = current.includes(value) ? current.filter((v) => v !== value) : [...current, value];
-    const url = buildUrl({ [key]: next });
-    startTransition(() => {
-      router.push(url, { scroll: false });
-    });
-  }
-
-  function toggleVariantGroup(ids: string[]) {
-    const current = searchParams.getAll("variantId");
-    const anySelected = ids.some((id) => current.includes(id));
-    const next = anySelected
-      ? current.filter((v) => !ids.includes(v))
-      : [...current, ...ids.filter((id) => !current.includes(id))];
-    const url = buildUrl({ variantId: next });
-    startTransition(() => {
-      router.push(url, { scroll: false });
-    });
-  }
-
-  function handleBrandToggle(brandId: string) {
-    const currentBrands = searchParams.getAll("brandId");
-    const isDeselecting = currentBrands.includes(brandId);
-    const nextBrands = isDeselecting
-      ? currentBrands.filter((b) => b !== brandId)
-      : [...currentBrands, brandId];
-
-    const url = buildUrl({ brandId: nextBrands });
-    startTransition(() => {
-      router.push(url, { scroll: false });
-    });
-  }
-
-  function setSort(value: string) {
-    const params = new URLSearchParams();
-    for (const [k, v] of searchParams.entries()) {
-      if (k !== "sort" && k !== "page") params.append(k, v);
-    }
-    if (value !== "price_asc") {
-      params.set("sort", value);
-    }
-    const qs = params.toString();
-    startTransition(() => {
-      router.push(qs ? `/?${qs}` : "/", { scroll: false });
-    });
-  }
-
   return (
-    <section
-      className={`${styles.panel}${isPending ? ` ${styles.pending}` : ""}`}
-      aria-label="Filter offers"
-    >
-      {/* Mobile toggle — hidden on desktop via CSS */}
-      <button
-        className={styles.toggle}
-        aria-expanded={isOpen}
-        aria-controls="filter-body"
-        onClick={() => setIsOpen((o) => !o)}
-      >
-        <span>Filter Offers{activeFilterCount > 0 ? ` (${activeFilterCount} active)` : ""}</span>
-        <span aria-hidden="true">{isOpen ? "▲" : "▼"}</span>
-      </button>
+    <section className={styles.panel} aria-label="Filter offers">
+      {/*
+       * <details> / <summary> provides the mobile collapse with zero JavaScript.
+       * On desktop, CSS forces the body to be permanently visible and hides the
+       * summary toggle, so the open attribute has no visible effect there.
+       */}
+      <details className={styles.disclosure} open>
+        <summary className={styles.toggle}>
+          <span>Filter Offers{activeFilterCount > 0 ? ` (${activeFilterCount} active)` : ""}</span>
+          <span aria-hidden="true" className={styles.toggleIcon}>&#9660;</span>
+        </summary>
 
-      {/* Body: collapsed on mobile until toggled, always visible on desktop */}
-      <div id="filter-body" className={isOpen ? styles.bodyOpen : styles.body}>
-        <div className={styles.panelHeader}>
-          <h2 id="filter-heading">Filter Offers</h2>
-          {hasAnyFilter && (
-            <Link href="/" className={styles.clearAll}>
-              Clear All
-            </Link>
-          )}
-        </div>
-
-        <div className={styles.groups}>
-          {/* Sort */}
-          <div className={styles.group}>
-            <p className={styles.groupLabel}>Sort By</p>
-            <ul className={styles.radioList} role="list">
-              {[
-                { value: "price_asc", label: "Price: Low to High" },
-                { value: "price_desc", label: "Price: High to Low" },
-                { value: "name_asc", label: "Brand: A to Z" },
-                { value: "name_desc", label: "Brand: Z to A" },
-              ].map(({ value, label }) => (
-                <li key={value} className={styles.radioItem}>
-                  <input
-                    type="radio"
-                    id={`sort-${value}`}
-                    name="sort"
-                    className={styles.radioInput}
-                    checked={currentSort === value}
-                    onChange={() => setSort(value)}
-                  />
-                  <label htmlFor={`sort-${value}`}>{label}</label>
-                </li>
-              ))}
-            </ul>
+        <div className={styles.body}>
+          <div className={styles.panelHeader}>
+            <h2 id="filter-heading">Filter Offers</h2>
+            {hasAnyFilter && (
+              <Link href="/" className={styles.clearAll}>
+                Clear All
+              </Link>
+            )}
           </div>
 
-          {/* Brand */}
-          {brands.length > 0 && (
+          <div className={styles.groups}>
+            {/* ── Sort ── */}
             <div className={styles.group}>
-              <p className={styles.groupLabel}>Brand</p>
-              <ul className={`${styles.checkList} ${styles.scrollable}`} role="list">
-                {brands.map((brand) => (
-                  <li key={brand.id} className={styles.checkItem}>
-                    <input
-                      type="checkbox"
-                      id={`brand-${brand.id}`}
-                      className={styles.checkInput}
-                      checked={selectedBrands.includes(brand.id)}
-                      onChange={() => handleBrandToggle(brand.id)}
-                    />
-                    <label htmlFor={`brand-${brand.id}`}>{brand.name}</label>
-                  </li>
-                ))}
+              <p className={styles.groupLabel} id="sort-group-label">Sort By</p>
+              <ul
+                className={styles.radioList}
+                role="radiogroup"
+                aria-labelledby="sort-group-label"
+              >
+                {[
+                  { value: "price_asc", label: "Price: Low to High" },
+                  { value: "price_desc", label: "Price: High to Low" },
+                  { value: "name_asc", label: "Brand: A to Z" },
+                  { value: "name_desc", label: "Brand: Z to A" },
+                ].map(({ value, label }) => {
+                  const checked = currentSort === value;
+                  return (
+                    <li key={value} role="presentation">
+                      <Link
+                        href={rawMapToUrl(setSort(map, value))}
+                        role="radio"
+                        aria-checked={checked}
+                        className={`${styles.radioItem}${checked ? ` ${styles.selected}` : ""}`}
+                      >
+                        <span className={styles.radioIndicator} aria-hidden="true" />
+                        {label}
+                      </Link>
+                    </li>
+                  );
+                })}
               </ul>
             </div>
-          )}
 
-          {/* Variant */}
-          {variantGroups.length > 0 && (
-            <div className={styles.group}>
-              <p className={styles.groupLabel}>Variant</p>
-              <ul className={`${styles.checkList} ${styles.scrollable}`} role="list">
-                {variantGroups.map((group) => (
-                  <li key={group.name} className={styles.checkItem}>
-                    <input
-                      type="checkbox"
-                      id={`variant-${group.name}`}
-                      className={styles.checkInput}
-                      checked={group.ids.some((id) => selectedVariants.includes(id))}
-                      onChange={() => toggleVariantGroup(group.ids)}
-                    />
-                    <label htmlFor={`variant-${group.name}`}>{group.name}</label>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
+            {/* ── Brand ── */}
+            {brands.length > 0 && (
+              <div className={styles.group}>
+                <p className={styles.groupLabel}>Brand</p>
+                <ul className={`${styles.checkList} ${styles.scrollable}`} role="list">
+                  {brands.map((brand) => {
+                    const checked = selectedBrands.includes(brand.id);
+                    return (
+                      <li key={brand.id}>
+                        <Link
+                          href={rawMapToUrl(toggleValue(map, "brandId", brand.id))}
+                          role="checkbox"
+                          aria-checked={checked}
+                          className={`${styles.checkItem}${checked ? ` ${styles.selected}` : ""}`}
+                        >
+                          <span className={styles.checkIndicator} aria-hidden="true" />
+                          {brand.name}
+                        </Link>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            )}
 
-          {/* Style */}
-          {stylesList.length > 0 && (
+            {/* ── Variant ── */}
+            {variantGroups.length > 0 && (
+              <div className={styles.group}>
+                <p className={styles.groupLabel}>Variant</p>
+                <ul className={`${styles.checkList} ${styles.scrollable}`} role="list">
+                  {variantGroups.map((group) => {
+                    const checked = group.ids.some((id) => selectedVariants.includes(id));
+                    return (
+                      <li key={group.name}>
+                        <Link
+                          href={rawMapToUrl(toggleVariantGroup(map, group.ids))}
+                          role="checkbox"
+                          aria-checked={checked}
+                          className={`${styles.checkItem}${checked ? ` ${styles.selected}` : ""}`}
+                        >
+                          <span className={styles.checkIndicator} aria-hidden="true" />
+                          {group.name}
+                        </Link>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            )}
+
+            {/* ── Style ── */}
+            {stylesList.length > 0 && (
+              <div className={styles.group}>
+                <p className={styles.groupLabel}>Style</p>
+                <ul className={styles.checkList} role="list">
+                  {stylesList.map((style) => {
+                    const checked = selectedStyles.includes(style.id);
+                    return (
+                      <li key={style.id}>
+                        <Link
+                          href={rawMapToUrl(toggleValue(map, "styleId", style.id))}
+                          role="checkbox"
+                          aria-checked={checked}
+                          className={`${styles.checkItem}${checked ? ` ${styles.selected}` : ""}`}
+                        >
+                          <span className={styles.checkIndicator} aria-hidden="true" />
+                          {style.name}
+                        </Link>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            )}
+
+            {/* ── Serving ── */}
             <div className={styles.group}>
-              <p className={styles.groupLabel}>Style</p>
+              <p className={styles.groupLabel}>Serving</p>
               <ul className={styles.checkList} role="list">
-                {stylesList.map((style) => (
-                  <li key={style.id} className={styles.checkItem}>
-                    <input
-                      type="checkbox"
-                      id={`style-${style.id}`}
-                      className={styles.checkInput}
-                      checked={selectedStyles.includes(style.id)}
-                      onChange={() => toggle("styleId", style.id)}
-                    />
-                    <label htmlFor={`style-${style.id}`}>{style.name}</label>
-                  </li>
-                ))}
+                {SERVING_TYPE_OPTIONS.map(({ value, label }) => {
+                  const checked = selectedServings.includes(value);
+                  return (
+                    <li key={value}>
+                      <Link
+                        href={rawMapToUrl(toggleValue(map, "serving", value))}
+                        role="checkbox"
+                        aria-checked={checked}
+                        className={`${styles.checkItem}${checked ? ` ${styles.selected}` : ""}`}
+                      >
+                        <span className={styles.checkIndicator} aria-hidden="true" />
+                        {label}
+                      </Link>
+                    </li>
+                  );
+                })}
               </ul>
             </div>
-          )}
 
-          {/* Serving */}
-          <div className={styles.group}>
-            <p className={styles.groupLabel}>Serving</p>
-            <ul className={styles.checkList} role="list">
-              {SERVING_TYPE_OPTIONS.map(({ value, label }) => (
-                <li key={value} className={styles.checkItem}>
-                  <input
-                    type="checkbox"
-                    id={`serving-${value}`}
-                    className={styles.checkInput}
-                    checked={selectedServings.includes(value)}
-                    onChange={() => toggle("serving", value)}
-                  />
-                  <label htmlFor={`serving-${value}`}>{label}</label>
-                </li>
-              ))}
-            </ul>
-          </div>
+            {/* ── Size ── */}
+            {sizes.length > 0 && (
+              <div className={styles.group}>
+                <p className={styles.groupLabel}>Size (ml)</p>
+                <ul className={styles.checkList} role="list">
+                  {sizes.map((size) => {
+                    const checked = selectedSizes.includes(String(size));
+                    return (
+                      <li key={size}>
+                        <Link
+                          href={rawMapToUrl(toggleValue(map, "sizeMl", String(size)))}
+                          role="checkbox"
+                          aria-checked={checked}
+                          className={`${styles.checkItem}${checked ? ` ${styles.selected}` : ""}`}
+                        >
+                          <span className={styles.checkIndicator} aria-hidden="true" />
+                          {size} ml
+                        </Link>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            )}
 
-          {/* Size */}
-          {sizes.length > 0 && (
+            {/* ── Location Type ── */}
             <div className={styles.group}>
-              <p className={styles.groupLabel}>Size (ml)</p>
+              <p className={styles.groupLabel}>Location Type</p>
               <ul className={styles.checkList} role="list">
-                {sizes.map((size) => (
-                  <li key={size} className={styles.checkItem}>
-                    <input
-                      type="checkbox"
-                      id={`size-${size}`}
-                      className={styles.checkInput}
-                      checked={selectedSizes.includes(String(size))}
-                      onChange={() => toggle("sizeMl", String(size))}
-                    />
-                    <label htmlFor={`size-${size}`}>{size} ml</label>
-                  </li>
-                ))}
+                {LOCATION_TYPE_OPTIONS.map(({ value, label }) => {
+                  const checked = selectedLocationTypes.includes(value);
+                  return (
+                    <li key={value}>
+                      <Link
+                        href={rawMapToUrl(toggleValue(map, "locationType", value))}
+                        role="checkbox"
+                        aria-checked={checked}
+                        className={`${styles.checkItem}${checked ? ` ${styles.selected}` : ""}`}
+                      >
+                        <span className={styles.checkIndicator} aria-hidden="true" />
+                        {label}
+                      </Link>
+                    </li>
+                  );
+                })}
               </ul>
             </div>
-          )}
 
-          {/* Location Type */}
-          <div className={styles.group}>
-            <p className={styles.groupLabel}>Location Type</p>
-            <ul className={styles.checkList} role="list">
-              {LOCATION_TYPE_OPTIONS.map(({ value, label }) => (
-                <li key={value} className={styles.checkItem}>
-                  <input
-                    type="checkbox"
-                    id={`loctype-${value}`}
-                    className={styles.checkInput}
-                    checked={selectedLocationTypes.includes(value)}
-                    onChange={() => toggle("locationType", value)}
-                  />
-                  <label htmlFor={`loctype-${value}`}>{label}</label>
-                </li>
-              ))}
-            </ul>
+            {/* ── Location ── */}
+            {locations.length > 0 && (
+              <div className={styles.group}>
+                <p className={styles.groupLabel}>Location</p>
+                <ul className={`${styles.checkList} ${styles.scrollable}`} role="list">
+                  {locations.map((location) => {
+                    const checked = selectedLocations.includes(location.id);
+                    return (
+                      <li key={location.id}>
+                        <Link
+                          href={rawMapToUrl(toggleValue(map, "locationId", location.id))}
+                          role="checkbox"
+                          aria-checked={checked}
+                          className={`${styles.checkItem}${checked ? ` ${styles.selected}` : ""}`}
+                        >
+                          <span className={styles.checkIndicator} aria-hidden="true" />
+                          {location.name}
+                        </Link>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            )}
           </div>
-
-          {/* Location */}
-          {locations.length > 0 && (
-            <div className={styles.group}>
-              <p className={styles.groupLabel}>Location</p>
-              <ul className={`${styles.checkList} ${styles.scrollable}`} role="list">
-                {locations.map((location) => (
-                  <li key={location.id} className={styles.checkItem}>
-                    <input
-                      type="checkbox"
-                      id={`location-${location.id}`}
-                      className={styles.checkInput}
-                      checked={selectedLocations.includes(location.id)}
-                      onChange={() => toggle("locationId", location.id)}
-                    />
-                    <label htmlFor={`location-${location.id}`}>{location.name}</label>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
         </div>
-      </div>
+      </details>
     </section>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from "react";
 import Link from "next/link";
 import { AdminOfferActions } from "@/components/admin-offer-actions";
 import { UserOfferActions } from "@/components/offer-user-actions";
@@ -17,43 +16,16 @@ import {
 } from "@/lib/query";
 import { parseBeerQueryRecord } from "@/lib/validation";
 import type { BeerBrand, BeerStyle, BeerVariant, Location } from "@/lib/types";
+import {
+  type SearchValue,
+  type RawMap,
+  toRawMap,
+  rawMapToUrl,
+  removeOneValue,
+  buildPaginationUrl,
+} from "@/lib/beer-directory-url";
 import { FilterPanel } from "./filter-panel";
 import styles from "./page.module.css";
-
-type SearchValue = string | string[] | undefined;
-
-type RawMap = Record<string, string[]>;
-
-function toRawMap(raw: Record<string, SearchValue>): RawMap {
-  const map: RawMap = {};
-  for (const [key, value] of Object.entries(raw)) {
-    if (Array.isArray(value)) {
-      const compact = value.filter(Boolean);
-      if (compact.length > 0) map[key] = compact;
-    } else if (value) {
-      map[key] = [value];
-    }
-  }
-  return map;
-}
-
-function rawMapToUrl(map: RawMap): string {
-  const params = new URLSearchParams();
-  for (const [key, values] of Object.entries(map)) {
-    for (const value of values) {
-      params.append(key, value);
-    }
-  }
-  const qs = params.toString();
-  return qs ? `/?${qs}` : "/";
-}
-
-function removeOneValue(map: RawMap, key: string, value: string): RawMap {
-  const next = { ...map };
-  next[key] = (next[key] ?? []).filter((v) => v !== value);
-  if (next[key].length === 0) delete next[key];
-  return next;
-}
 
 type ActiveChip = { label: string; removeUrl: string };
 
@@ -86,7 +58,7 @@ function buildActiveChips(
     }
   }
   for (const [name, ids] of variantChipGroups.entries()) {
-    let nextMap = map;
+    let nextMap: RawMap = map;
     for (const id of ids) {
       nextMap = removeOneValue(nextMap, "variantId", id);
     }
@@ -155,21 +127,6 @@ function buildActiveChips(
   return chips;
 }
 
-function buildPageUrl(raw: Record<string, SearchValue>, targetPage: number): string {
-  const params = new URLSearchParams();
-  for (const [key, value] of Object.entries(raw)) {
-    if (key === "page") continue;
-    if (Array.isArray(value)) {
-      for (const v of value) params.append(key, v);
-    } else if (value) {
-      params.append(key, value);
-    }
-  }
-  if (targetPage > 1) params.set("page", String(targetPage));
-  const qs = params.toString();
-  return qs ? `/?${qs}` : "/";
-}
-
 export default async function Home({
   searchParams,
 }: {
@@ -227,21 +184,14 @@ export default async function Home({
       </header>
 
       <main className={styles.main}>
-        <Suspense
-          fallback={
-            <section className={styles.panel} aria-labelledby="filter-heading">
-              <h2 id="filter-heading">Filter Offers</h2>
-            </section>
-          }
-        >
-          <FilterPanel
-            brands={brands.map((b) => ({ id: b.id, name: b.name }))}
-            variants={variants.map((v) => ({ id: v.id, name: v.name, brandId: v.brandId }))}
-            stylesList={stylesList.map((s) => ({ id: s.id, name: s.name }))}
-            sizes={sizes}
-            locations={locations.map((l) => ({ id: l.id, name: l.name }))}
-          />
-        </Suspense>
+        <FilterPanel
+          brands={brands.map((b) => ({ id: b.id, name: b.name }))}
+          variants={variants.map((v) => ({ id: v.id, name: v.name, brandId: v.brandId }))}
+          stylesList={stylesList.map((s) => ({ id: s.id, name: s.name }))}
+          sizes={sizes}
+          locations={locations.map((l) => ({ id: l.id, name: l.name }))}
+          searchParams={rawSearchParams}
+        />
 
         <section className={styles.panel} aria-labelledby="results-heading">
           <h2 id="results-heading">Offers ({total})</h2>
@@ -320,7 +270,7 @@ export default async function Home({
                 <nav className={styles.pagination} aria-label="Offer pages">
                   {page > 1 ? (
                     <Link
-                      href={buildPageUrl(rawSearchParams, page - 1)}
+                      href={buildPaginationUrl(rawSearchParams, page - 1)}
                       className={styles.pageLink}
                     >
                       &larr; Prev
@@ -333,7 +283,7 @@ export default async function Home({
                   </span>
                   {page < totalPages ? (
                     <Link
-                      href={buildPageUrl(rawSearchParams, page + 1)}
+                      href={buildPaginationUrl(rawSearchParams, page + 1)}
                       className={styles.pageLink}
                     >
                       Next &rarr;

--- a/src/lib/beer-directory-url.ts
+++ b/src/lib/beer-directory-url.ts
@@ -1,0 +1,121 @@
+/**
+ * Pure URL helpers for the beer directory page.
+ *
+ * All functions are side-effect-free and work with a plain RawMap so they can
+ * be used in server components, route handlers, and unit tests without a
+ * browser or React runtime.
+ */
+
+export type SearchValue = string | string[] | undefined;
+
+/** A normalized representation of URL search params. */
+export type RawMap = Record<string, string[]>;
+
+/**
+ * Normalize raw Next.js searchParams (where each value may be a string,
+ * string[], or undefined) into a compact RawMap.  Blank/empty values are
+ * dropped so downstream code never sees empty strings.
+ */
+export function toRawMap(raw: Record<string, SearchValue>): RawMap {
+  const map: RawMap = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (Array.isArray(value)) {
+      const compact = value.filter(Boolean);
+      if (compact.length > 0) map[key] = compact;
+    } else if (value) {
+      map[key] = [value];
+    }
+  }
+  return map;
+}
+
+/** Serialize a RawMap back to an absolute URL string rooted at "/". */
+export function rawMapToUrl(map: RawMap): string {
+  const params = new URLSearchParams();
+  for (const [key, values] of Object.entries(map)) {
+    for (const value of values) {
+      params.append(key, value);
+    }
+  }
+  const qs = params.toString();
+  return qs ? `/?${qs}` : "/";
+}
+
+/**
+ * Remove a single occurrence of `value` from the `key` array in `map`.
+ * If the array becomes empty the key is deleted.
+ * Does NOT drop `page` — use this for chip removal where page is preserved.
+ */
+export function removeOneValue(map: RawMap, key: string, value: string): RawMap {
+  const next = { ...map };
+  next[key] = (next[key] ?? []).filter((v) => v !== value);
+  if (next[key].length === 0) delete next[key];
+  return next;
+}
+
+/** Internal helper — always drop `page` on any filter change. */
+function dropPage(map: RawMap): RawMap {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { page: _page, ...rest } = map;
+  return rest;
+}
+
+/**
+ * Toggle a single value within a multi-select key, resetting pagination.
+ * If `value` is already present it is removed; otherwise it is appended.
+ */
+export function toggleValue(map: RawMap, key: string, value: string): RawMap {
+  const current = map[key] ?? [];
+  const next = current.includes(value)
+    ? current.filter((v) => v !== value)
+    : [...current, value];
+  const updated = { ...map, [key]: next };
+  if (next.length === 0) delete updated[key];
+  return dropPage(updated);
+}
+
+/**
+ * Toggle a variant group (one or more IDs that share a display name).
+ * If any of the IDs are currently selected the whole group is deselected;
+ * otherwise all IDs in the group are added.  Resets pagination.
+ */
+export function toggleVariantGroup(map: RawMap, ids: string[]): RawMap {
+  const current = map.variantId ?? [];
+  const anySelected = ids.some((id) => current.includes(id));
+  const next = anySelected
+    ? current.filter((v) => !ids.includes(v))
+    : [...current, ...ids.filter((id) => !current.includes(id))];
+  if (next.length === 0) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { variantId: _variantId, ...rest } = map;
+    return dropPage(rest);
+  }
+  return dropPage({ ...map, variantId: next });
+}
+
+/**
+ * Replace the `sort` value.  Omits the key entirely when `value` is the
+ * default ("price_asc") to keep URLs canonical.  Always resets pagination.
+ */
+export function setSort(map: RawMap, value: string): RawMap {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { sort: _sort, ...withoutSort } = dropPage(map);
+  if (value !== "price_asc") {
+    return { ...withoutSort, sort: [value] };
+  }
+  return withoutSort;
+}
+
+/**
+ * Build a pagination URL for `targetPage`, preserving all current filters.
+ * Omits the `page` param entirely when `targetPage` is 1 for canonical URLs.
+ */
+export function buildPaginationUrl(
+  raw: Record<string, SearchValue>,
+  targetPage: number,
+): string {
+  const map = toRawMap(raw);
+  delete map.page;
+  if (targetPage > 1) map.page = [String(targetPage)];
+  return rawMapToUrl(map);
+}


### PR DESCRIPTION
- Extract URL manipulation functions (toRawMap, rawMapToUrl, removeOneValue, buildPaginationUrl) from page.tsx into a new beer-directory-url module
- Remove Suspense wrapper from FilterPanel
- Convert FilterPanel from client to server component and pass searchParams as prop instead of using useSearchParams hook
- Rename buildPageUrl to buildPaginationUrl for clarity