### PR TITLE
expand-test-coverage

### DIFF
--- a/__tests__/api/authorization-matrix.route.test.ts
+++ b/__tests__/api/authorization-matrix.route.test.ts
@@ -1,26 +1,146 @@
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 
-const mockedRequireAuthUser = jest.fn<() => Promise<{ id: string; displayName: string }>>();
-const mockedRequireModeratorUser =
-  jest.fn<() => Promise<{ id: string; displayName: string; role: string }>>();
-const mockedRequireAdminUser =
-  jest.fn<() => Promise<{ id: string; displayName: string; role: string }>>();
+type AuthUser = {
+  id: string;
+  email: string;
+  displayName: string;
+  role: "user" | "moderator" | "admin";
+};
+
+type ReportRecord = {
+  id: string;
+  status: "open" | "dismissed" | "actioned";
+  contentType: string;
+  contentId: string;
+  reason: string;
+  reporter: { displayName: string } | null;
+};
+
+const authUser: AuthUser = {
+  id: "user-1",
+  email: "user@example.com",
+  displayName: "User One",
+  role: "user",
+};
+
+const moderatorUser: AuthUser = {
+  id: "moderator-1",
+  email: "moderator@example.com",
+  displayName: "Moderator One",
+  role: "moderator",
+};
+
+const adminUser: AuthUser = {
+  id: "admin-1",
+  email: "admin@example.com",
+  displayName: "Admin One",
+  role: "admin",
+};
+
+const mockedRequireAuthUser = jest.fn<() => Promise<AuthUser>>();
+const mockedRequireModeratorUser = jest.fn<() => Promise<AuthUser>>();
+const mockedRequireAdminUser = jest.fn<() => Promise<AuthUser>>();
 const mockedGetBeerOffersPage = jest.fn<() => Promise<{ offers: unknown[]; total: number }>>();
-const mockedRequestEmailChange =
+const mockedGetLocationReviewPermission =
+  jest.fn<() => Promise<"allowed" | "missing" | "forbidden">>();
+const mockedGetLocationReviews = jest.fn<() => Promise<unknown[]>>();
+const mockedCreateLocation =
   jest.fn<
-    (
-      userId: string,
-      newEmail: string,
-      currentPassword: string,
-    ) => Promise<{ ok: true; token: string } | { ok: false; code: string }>
+    (input: {
+      name: string;
+      locationType: string;
+      district: string;
+      address: string;
+      createdById: string;
+      status: string;
+    }) => Promise<{ id: string; name: string }>
   >();
-const mockedSendEmailChangeVerificationEmail = jest.fn<() => Promise<void>>();
+const mockedCreateReview =
+  jest.fn<
+    (input: {
+      locationId: string;
+      userId: string;
+      rating: number;
+      title?: string;
+      body?: string;
+    }) => Promise<{ id: string; locationId: string; userId: string }>
+  >();
+const mockedHasUserReportedContent = jest.fn<() => Promise<boolean>>();
+const mockedCreateReport =
+  jest.fn<
+    (input: {
+      reporterId: string;
+      contentType: string;
+      contentId: string;
+      reason: string;
+      note?: string;
+    }) => Promise<{ id: string; contentId: string }>
+  >();
+const mockedGetLocationContributionPermission =
+  jest.fn<() => Promise<"allowed" | "missing" | "forbidden">>();
+const mockedGetVariantContributionPermission =
+  jest.fn<() => Promise<"allowed" | "missing" | "forbidden">>();
+const mockedCreateOfferOrPriceUpdateProposal = jest.fn<
+  () => Promise<
+    | {
+        outcome: "offer";
+        offer: { id: string; locationId: string; variantId: string };
+      }
+    | {
+        outcome: "price_update";
+        offer: { id: string };
+        proposal: { id: string };
+      }
+    | { outcome: "existing_offer_not_approved" }
+    | { outcome: "same_price" }
+  >
+>();
 const mockedGetPendingLocationSubmissions = jest.fn<() => Promise<unknown[]>>();
 const mockedGetPendingBeerBrandSubmissions = jest.fn<() => Promise<unknown[]>>();
 const mockedGetPendingBeerVariantSubmissions = jest.fn<() => Promise<unknown[]>>();
 const mockedGetPendingBeerOfferSubmissions = jest.fn<() => Promise<unknown[]>>();
 const mockedGetPendingPriceUpdateProposals = jest.fn<() => Promise<unknown[]>>();
+const mockedGetOpenReports = jest.fn<() => Promise<unknown[]>>();
+const mockedGetReportById = jest.fn<() => Promise<ReportRecord | null>>();
+const mockedResolveReport = jest.fn<() => Promise<{ id: string; status: string } | null>>();
+const mockedModerateBeerOfferSubmission = jest.fn<
+  () => Promise<
+    | {
+        outcome: "updated";
+        offer: {
+          id: string;
+          brand: string;
+          variant: string;
+          style: string;
+          sizeMl: number;
+          serving: string;
+          priceEur: number;
+          location: { name: string };
+        };
+      }
+    | { outcome: "missing" }
+    | { outcome: "location_not_approved" }
+    | { outcome: "variant_not_approved" }
+  >
+>();
+const mockedLogModerationAction = jest.fn<() => Promise<void>>();
 const mockedGetUsersForAdmin = jest.fn<() => Promise<unknown[]>>();
+const mockedUpdateUserRoleByAdmin =
+  jest.fn<
+    (input: {
+      targetUserId: string;
+      role: string;
+      actingAdminId: string;
+    }) => Promise<
+      | { outcome: "updated"; user: { id: string; role: string } }
+      | { outcome: "not_found" }
+      | { outcome: "cannot_demote_last_admin" }
+    >
+  >();
+const mockedCreateBeerOffer =
+  jest.fn<
+    () => Promise<{ id: string; brand: string; variant: string; sizeMl: number; priceEur: number }>
+  >();
 
 jest.mock("@/lib/auth", () => {
   class UnauthorizedError extends Error {
@@ -43,146 +163,637 @@ jest.mock("@/lib/auth", () => {
     requireAuthUser: mockedRequireAuthUser,
     requireModeratorUser: mockedRequireModeratorUser,
     requireAdminUser: mockedRequireAdminUser,
-    requestEmailChange: mockedRequestEmailChange,
   };
 });
 
 jest.mock("@/lib/query", () => ({
   BEER_OFFERS_PAGE_SIZE: 20,
-  createOfferOrPriceUpdateProposal: jest.fn(),
+  createLocation: mockedCreateLocation,
+  createReview: mockedCreateReview,
+  getLocationReviewPermission: mockedGetLocationReviewPermission,
+  getLocationReviews: mockedGetLocationReviews,
+  hasUserReportedContent: mockedHasUserReportedContent,
+  createReport: mockedCreateReport,
+  getLocationContributionPermission: mockedGetLocationContributionPermission,
+  getVariantContributionPermission: mockedGetVariantContributionPermission,
+  createOfferOrPriceUpdateProposal: mockedCreateOfferOrPriceUpdateProposal,
   getBeerOffersPage: mockedGetBeerOffersPage,
-  getLocationContributionPermission: jest.fn(),
-  getVariantContributionPermission: jest.fn(),
   getPendingLocationSubmissions: mockedGetPendingLocationSubmissions,
   getPendingBeerBrandSubmissions: mockedGetPendingBeerBrandSubmissions,
   getPendingBeerVariantSubmissions: mockedGetPendingBeerVariantSubmissions,
   getPendingBeerOfferSubmissions: mockedGetPendingBeerOfferSubmissions,
   getPendingPriceUpdateProposals: mockedGetPendingPriceUpdateProposals,
+  getOpenReports: mockedGetOpenReports,
+  getReportById: mockedGetReportById,
+  resolveReport: mockedResolveReport,
+  moderateBeerOfferSubmission: mockedModerateBeerOfferSubmission,
+  logModerationAction: mockedLogModerationAction,
   getUsersForAdmin: mockedGetUsersForAdmin,
+  updateUserRoleByAdmin: mockedUpdateUserRoleByAdmin,
+  createBeerOffer: mockedCreateBeerOffer,
 }));
 
-jest.mock("@/lib/email", () => ({
-  sendEmailChangeVerificationEmail: mockedSendEmailChangeVerificationEmail,
-}));
+async function parseJson<T>(response: Response): Promise<T> {
+  return (await response.json()) as T;
+}
 
-jest.mock("@/lib/verification", () => ({
-  buildVerificationUrl: jest.fn(() => "http://localhost/verify-email?token=test-token"),
-}));
+async function expectUnauthorized(
+  run: () => Promise<Response>,
+): Promise<{ status: string; error: { code: string; message: string } }> {
+  const response = await run();
+  const body = await parseJson<{ status: string; error: { code: string; message: string } }>(
+    response,
+  );
+
+  expect(response.status).toBe(401);
+  expect(body.status).toBe("error");
+  expect(body.error.code).toBe("UNAUTHORIZED");
+
+  return body;
+}
+
+async function expectForbidden(
+  run: () => Promise<Response>,
+): Promise<{ status: string; error: { code: string; message: string } }> {
+  const response = await run();
+  const body = await parseJson<{ status: string; error: { code: string; message: string } }>(
+    response,
+  );
+
+  expect(response.status).toBe(403);
+  expect(body.status).toBe("error");
+  expect(body.error.code).toBe("FORBIDDEN");
+
+  return body;
+}
 
 describe("API authorization matrix", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it("allows public directory access without authentication", async () => {
-    mockedGetBeerOffersPage.mockResolvedValueOnce({ offers: [], total: 0 });
+  describe("public routes", () => {
+    it("allows anonymous access to the public offer directory", async () => {
+      mockedGetBeerOffersPage.mockResolvedValueOnce({ offers: [], total: 0 });
 
-    const { GET } = await import("@/app/api/v1/beers/route");
-    const response = await GET(new Request("http://localhost/api/v1/beers"));
+      const { GET } = await import("@/app/api/v1/beers/route");
+      const response = await GET(new Request("http://localhost/api/v1/beers"));
+      const body = await parseJson<{
+        status: string;
+        data: { offers: unknown[]; pagination: { page: number; total: number } };
+      }>(response);
 
-    expect(response.status).toBe(200);
-    expect(mockedRequireAuthUser).not.toHaveBeenCalled();
+      expect(response.status).toBe(200);
+      expect(body.status).toBe("ok");
+      expect(body.data.offers).toEqual([]);
+      expect(body.data.pagination.page).toBe(1);
+      expect(mockedRequireAuthUser).not.toHaveBeenCalled();
+    });
+
+    it("allows anonymous access to public review listings", async () => {
+      mockedGetLocationReviewPermission.mockResolvedValueOnce("allowed");
+      mockedGetLocationReviews.mockResolvedValueOnce([{ id: "review-1" }]);
+
+      const { GET } = await import("@/app/api/v1/reviews/route");
+      const response = await GET(new Request("http://localhost/api/v1/reviews?locationId=loc-1"));
+      const body = await parseJson<{
+        status: string;
+        data: { locationId: string; count: number; reviews: Array<{ id: string }> };
+      }>(response);
+
+      expect(response.status).toBe(200);
+      expect(body.status).toBe("ok");
+      expect(body.data.locationId).toBe("loc-1");
+      expect(body.data.count).toBe(1);
+      expect(mockedRequireAuthUser).not.toHaveBeenCalled();
+    });
   });
 
-  it("rejects anonymous access to authenticated routes", async () => {
-    const auth = await import("@/lib/auth");
-    mockedRequireAuthUser.mockRejectedValueOnce(new auth.UnauthorizedError());
+  describe("authenticated routes", () => {
+    it.each([
+      {
+        name: "GET /auth/me",
+        run: async () => {
+          const { GET } = await import("@/app/api/v1/auth/me/route");
+          return GET();
+        },
+      },
+      {
+        name: "POST /locations",
+        run: async () => {
+          const { POST } = await import("@/app/api/v1/locations/route");
+          return POST(
+            new Request("http://localhost/api/v1/locations", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                name: "Test Pub",
+                locationType: "pub",
+                district: "Mitte",
+                address: "Street 1",
+              }),
+            }),
+          );
+        },
+      },
+      {
+        name: "POST /reviews",
+        run: async () => {
+          const { POST } = await import("@/app/api/v1/reviews/route");
+          return POST(
+            new Request("http://localhost/api/v1/reviews", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                locationId: "loc-1",
+                rating: 4,
+                title: "Solid",
+                body: "Nice",
+              }),
+            }),
+          );
+        },
+      },
+      {
+        name: "POST /reports",
+        run: async () => {
+          const { POST } = await import("@/app/api/v1/reports/route");
+          return POST(
+            new Request("http://localhost/api/v1/reports", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                contentType: "review",
+                contentId: "review-1",
+                reason: "offensive",
+                note: "Bad content",
+              }),
+            }),
+          );
+        },
+      },
+      {
+        name: "POST /beers",
+        run: async () => {
+          const { POST } = await import("@/app/api/v1/beers/route");
+          return POST(
+            new Request("http://localhost/api/v1/beers", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                variantId: "variant-1",
+                sizeMl: 500,
+                serving: "tap",
+                priceCents: 499,
+                locationId: "loc-1",
+              }),
+            }),
+          );
+        },
+      },
+    ])("rejects anonymous access to $name", async ({ run }) => {
+      const auth = await import("@/lib/auth");
+      mockedRequireAuthUser.mockRejectedValueOnce(new auth.UnauthorizedError());
 
-    const { POST } = await import("@/app/api/v1/auth/change-email/route");
-    const response = await POST(
-      new Request("http://localhost/api/v1/auth/change-email", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          newEmail: "new@example.com",
-          currentPassword: "password123",
+      await expectUnauthorized(run);
+    });
+
+    it("allows authenticated access to GET /auth/me", async () => {
+      mockedRequireAuthUser.mockResolvedValueOnce(authUser);
+
+      const { GET } = await import("@/app/api/v1/auth/me/route");
+      const response = await GET();
+      const body = await parseJson<{ status: string; data: { user: AuthUser } }>(response);
+
+      expect(response.status).toBe(200);
+      expect(body.status).toBe("ok");
+      expect(body.data.user.id).toBe(authUser.id);
+    });
+
+    it("allows authenticated users to submit locations", async () => {
+      mockedRequireAuthUser.mockResolvedValueOnce(authUser);
+      mockedCreateLocation.mockResolvedValueOnce({ id: "loc-1", name: "Test Pub" });
+
+      const { POST } = await import("@/app/api/v1/locations/route");
+      const response = await POST(
+        new Request("http://localhost/api/v1/locations", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "Test Pub",
+            locationType: "pub",
+            district: "Mitte",
+            address: "Street 1",
+          }),
         }),
-      }),
-    );
-    const body = (await response.json()) as { error: { code: string } };
+      );
+      const body = await parseJson<{ status: string; data: { location: { id: string } } }>(
+        response,
+      );
 
-    expect(response.status).toBe(401);
-    expect(body.error.code).toBe("UNAUTHORIZED");
-  });
-
-  it("rejects anonymous moderator access", async () => {
-    const auth = await import("@/lib/auth");
-    mockedRequireModeratorUser.mockRejectedValueOnce(new auth.UnauthorizedError());
-
-    const { GET } = await import("@/app/api/v1/moderation/submissions/route");
-    const response = await GET();
-    const body = (await response.json()) as { error: { code: string } };
-
-    expect(response.status).toBe(401);
-    expect(body.error.code).toBe("UNAUTHORIZED");
-  });
-
-  it("rejects non-moderators from moderator routes", async () => {
-    const auth = await import("@/lib/auth");
-    mockedRequireModeratorUser.mockRejectedValueOnce(new auth.ForbiddenError());
-
-    const { GET } = await import("@/app/api/v1/moderation/submissions/route");
-    const response = await GET();
-    const body = (await response.json()) as { error: { code: string } };
-
-    expect(response.status).toBe(403);
-    expect(body.error.code).toBe("FORBIDDEN");
-  });
-
-  it("allows moderators to access moderator routes", async () => {
-    mockedRequireModeratorUser.mockResolvedValueOnce({
-      id: "moderator-1",
-      displayName: "Moderator",
-      role: "moderator",
+      expect(response.status).toBe(201);
+      expect(body.status).toBe("ok");
+      expect(body.data.location.id).toBe("loc-1");
+      expect(mockedCreateLocation).toHaveBeenCalledWith(
+        expect.objectContaining({ createdById: authUser.id, status: "pending" }),
+      );
     });
-    mockedGetPendingLocationSubmissions.mockResolvedValueOnce([]);
-    mockedGetPendingBeerBrandSubmissions.mockResolvedValueOnce([]);
-    mockedGetPendingBeerVariantSubmissions.mockResolvedValueOnce([]);
-    mockedGetPendingBeerOfferSubmissions.mockResolvedValueOnce([]);
-    mockedGetPendingPriceUpdateProposals.mockResolvedValueOnce([]);
 
-    const { GET } = await import("@/app/api/v1/moderation/submissions/route");
-    const response = await GET();
+    it("allows authenticated users to submit reviews", async () => {
+      mockedRequireAuthUser.mockResolvedValueOnce(authUser);
+      mockedGetLocationReviewPermission.mockResolvedValueOnce("allowed");
+      mockedCreateReview.mockResolvedValueOnce({
+        id: "review-1",
+        locationId: "loc-1",
+        userId: authUser.id,
+      });
 
-    expect(response.status).toBe(200);
-  });
+      const { POST } = await import("@/app/api/v1/reviews/route");
+      const response = await POST(
+        new Request("http://localhost/api/v1/reviews", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ locationId: "loc-1", rating: 4, title: "Solid", body: "Nice" }),
+        }),
+      );
+      const body = await parseJson<{ status: string; data: { review: { id: string } } }>(response);
 
-  it("rejects anonymous admin access", async () => {
-    const auth = await import("@/lib/auth");
-    mockedRequireAdminUser.mockRejectedValueOnce(new auth.UnauthorizedError());
-
-    const { GET } = await import("@/app/api/v1/admin/users/route");
-    const response = await GET();
-    const body = (await response.json()) as { error: { code: string } };
-
-    expect(response.status).toBe(401);
-    expect(body.error.code).toBe("UNAUTHORIZED");
-  });
-
-  it("rejects non-admins from admin routes", async () => {
-    const auth = await import("@/lib/auth");
-    mockedRequireAdminUser.mockRejectedValueOnce(new auth.ForbiddenError());
-
-    const { GET } = await import("@/app/api/v1/admin/users/route");
-    const response = await GET();
-    const body = (await response.json()) as { error: { code: string } };
-
-    expect(response.status).toBe(403);
-    expect(body.error.code).toBe("FORBIDDEN");
-  });
-
-  it("allows admins to access admin routes", async () => {
-    mockedRequireAdminUser.mockResolvedValueOnce({
-      id: "admin-1",
-      displayName: "Admin",
-      role: "admin",
+      expect(response.status).toBe(201);
+      expect(body.status).toBe("ok");
+      expect(body.data.review.id).toBe("review-1");
+      expect(mockedCreateReview).toHaveBeenCalledWith(
+        expect.objectContaining({ locationId: "loc-1", userId: authUser.id, rating: 4 }),
+      );
     });
-    mockedGetUsersForAdmin.mockResolvedValueOnce([]);
 
-    const { GET } = await import("@/app/api/v1/admin/users/route");
-    const response = await GET();
+    it("allows authenticated users to submit reports", async () => {
+      mockedRequireAuthUser.mockResolvedValueOnce(authUser);
+      mockedHasUserReportedContent.mockResolvedValueOnce(false);
+      mockedCreateReport.mockResolvedValueOnce({ id: "report-1", contentId: "review-1" });
 
-    expect(response.status).toBe(200);
-    expect(mockedGetUsersForAdmin).toHaveBeenCalledTimes(1);
+      const { POST } = await import("@/app/api/v1/reports/route");
+      const response = await POST(
+        new Request("http://localhost/api/v1/reports", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            contentType: "review",
+            contentId: "review-1",
+            reason: "offensive",
+            note: "Bad content",
+          }),
+        }),
+      );
+      const body = await parseJson<{ status: string; data: { report: { id: string } } }>(response);
+
+      expect(response.status).toBe(201);
+      expect(body.status).toBe("ok");
+      expect(body.data.report.id).toBe("report-1");
+      expect(mockedCreateReport).toHaveBeenCalledWith(
+        expect.objectContaining({ reporterId: authUser.id, contentId: "review-1" }),
+      );
+    });
+
+    it("allows authenticated users to submit offers or price updates", async () => {
+      mockedRequireAuthUser.mockResolvedValueOnce(authUser);
+      mockedGetLocationContributionPermission.mockResolvedValueOnce("allowed");
+      mockedGetVariantContributionPermission.mockResolvedValueOnce("allowed");
+      mockedCreateOfferOrPriceUpdateProposal.mockResolvedValueOnce({
+        outcome: "offer",
+        offer: { id: "offer-1", locationId: "loc-1", variantId: "variant-1" },
+      });
+
+      const { POST } = await import("@/app/api/v1/beers/route");
+      const response = await POST(
+        new Request("http://localhost/api/v1/beers", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            variantId: "variant-1",
+            sizeMl: 500,
+            serving: "tap",
+            priceCents: 499,
+            locationId: "loc-1",
+          }),
+        }),
+      );
+      const body = await parseJson<{
+        status: string;
+        data: { outcome: string; offer: { id: string } };
+      }>(response);
+
+      expect(response.status).toBe(201);
+      expect(body.status).toBe("ok");
+      expect(body.data.outcome).toBe("offer_submission_created");
+      expect(body.data.offer.id).toBe("offer-1");
+    });
+  });
+
+  describe("moderator routes", () => {
+    const moderatorCases = [
+      {
+        name: "GET /moderation/submissions",
+        run: async () => {
+          const { GET } = await import("@/app/api/v1/moderation/submissions/route");
+          return GET();
+        },
+      },
+      {
+        name: "GET /moderation/reports",
+        run: async () => {
+          const { GET } = await import("@/app/api/v1/moderation/reports/route");
+          return GET();
+        },
+      },
+      {
+        name: "PATCH /moderation/reports/:id",
+        run: async () => {
+          const { PATCH } = await import("@/app/api/v1/moderation/reports/[reportId]/route");
+          return PATCH(
+            new Request("http://localhost/api/v1/moderation/reports/report-1", {
+              method: "PATCH",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ decision: "dismissed" }),
+            }),
+            { params: Promise.resolve({ reportId: "report-1" }) },
+          );
+        },
+      },
+      {
+        name: "PATCH /moderation/offers/:id",
+        run: async () => {
+          const { PATCH } = await import("@/app/api/v1/moderation/offers/[offerId]/route");
+          return PATCH(
+            new Request("http://localhost/api/v1/moderation/offers/offer-1", {
+              method: "PATCH",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ status: "approved" }),
+            }),
+            { params: Promise.resolve({ offerId: "offer-1" }) },
+          );
+        },
+      },
+    ];
+
+    it.each(moderatorCases)("rejects anonymous access to $name", async ({ run }) => {
+      const auth = await import("@/lib/auth");
+      mockedRequireModeratorUser.mockRejectedValueOnce(new auth.UnauthorizedError());
+
+      const body = await expectUnauthorized(run);
+      expect(body.error.message).toBe("Authentication required.");
+    });
+
+    it.each(moderatorCases)("rejects non-moderators from $name", async ({ run }) => {
+      const auth = await import("@/lib/auth");
+      mockedRequireModeratorUser.mockRejectedValueOnce(new auth.ForbiddenError());
+
+      const body = await expectForbidden(run);
+      expect(body.error.message).toBe("Moderator permissions required.");
+    });
+
+    it("allows moderators to access moderation submissions", async () => {
+      mockedRequireModeratorUser.mockResolvedValueOnce(moderatorUser);
+      mockedGetPendingLocationSubmissions.mockResolvedValueOnce([{ id: "loc-1" }]);
+      mockedGetPendingBeerBrandSubmissions.mockResolvedValueOnce([{ id: "brand-1" }]);
+      mockedGetPendingBeerVariantSubmissions.mockResolvedValueOnce([{ id: "variant-1" }]);
+      mockedGetPendingBeerOfferSubmissions.mockResolvedValueOnce([{ id: "offer-1" }]);
+      mockedGetPendingPriceUpdateProposals.mockResolvedValueOnce([{ id: "proposal-1" }]);
+
+      const { GET } = await import("@/app/api/v1/moderation/submissions/route");
+      const response = await GET();
+      const body = await parseJson<{
+        status: string;
+        data: { counts: { locations: number; brands: number; variants: number; offers: number } };
+      }>(response);
+
+      expect(response.status).toBe(200);
+      expect(body.status).toBe("ok");
+      expect(body.data.counts.locations).toBe(1);
+      expect(body.data.counts.brands).toBe(1);
+      expect(body.data.counts.variants).toBe(1);
+      expect(body.data.counts.offers).toBe(1);
+    });
+
+    it("allows moderators to access open reports", async () => {
+      mockedRequireModeratorUser.mockResolvedValueOnce(moderatorUser);
+      mockedGetOpenReports.mockResolvedValueOnce([{ id: "report-1" }]);
+
+      const { GET } = await import("@/app/api/v1/moderation/reports/route");
+      const response = await GET();
+      const body = await parseJson<{ status: string; data: { reports: Array<{ id: string }> } }>(
+        response,
+      );
+
+      expect(response.status).toBe(200);
+      expect(body.status).toBe("ok");
+      expect(body.data.reports[0]?.id).toBe("report-1");
+    });
+
+    it("allows moderators to resolve reports", async () => {
+      mockedRequireModeratorUser.mockResolvedValueOnce(moderatorUser);
+      mockedGetReportById.mockResolvedValueOnce({
+        id: "report-1",
+        status: "open",
+        contentType: "review",
+        contentId: "review-1",
+        reason: "offensive",
+        reporter: { displayName: "Reporter" },
+      });
+      mockedResolveReport.mockResolvedValueOnce({ id: "report-1", status: "dismissed" });
+      mockedLogModerationAction.mockResolvedValueOnce();
+
+      const { PATCH } = await import("@/app/api/v1/moderation/reports/[reportId]/route");
+      const response = await PATCH(
+        new Request("http://localhost/api/v1/moderation/reports/report-1", {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ decision: "dismissed" }),
+        }),
+        { params: Promise.resolve({ reportId: "report-1" }) },
+      );
+      const body = await parseJson<{
+        status: string;
+        data: { report: { id: string; status: string } };
+      }>(response);
+
+      expect(response.status).toBe(200);
+      expect(body.status).toBe("ok");
+      expect(body.data.report.status).toBe("dismissed");
+      expect(mockedLogModerationAction).toHaveBeenCalledTimes(1);
+    });
+
+    it("allows moderators to approve offer submissions", async () => {
+      mockedRequireModeratorUser.mockResolvedValueOnce(moderatorUser);
+      mockedModerateBeerOfferSubmission.mockResolvedValueOnce({
+        outcome: "updated",
+        offer: {
+          id: "offer-1",
+          brand: "Brand",
+          variant: "Variant",
+          style: "Pils",
+          sizeMl: 500,
+          serving: "tap",
+          priceEur: 4.99,
+          location: { name: "Pub 1" },
+        },
+      });
+      mockedLogModerationAction.mockResolvedValueOnce();
+
+      const { PATCH } = await import("@/app/api/v1/moderation/offers/[offerId]/route");
+      const response = await PATCH(
+        new Request("http://localhost/api/v1/moderation/offers/offer-1", {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "approved" }),
+        }),
+        { params: Promise.resolve({ offerId: "offer-1" }) },
+      );
+      const body = await parseJson<{ status: string; data: { offer: { id: string } } }>(response);
+
+      expect(response.status).toBe(200);
+      expect(body.status).toBe("ok");
+      expect(body.data.offer.id).toBe("offer-1");
+      expect(mockedLogModerationAction).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("admin routes", () => {
+    const adminCases = [
+      {
+        name: "GET /admin/users",
+        run: async () => {
+          const { GET } = await import("@/app/api/v1/admin/users/route");
+          return GET();
+        },
+      },
+      {
+        name: "PATCH /admin/users/:id/role",
+        run: async () => {
+          const { PATCH } = await import("@/app/api/v1/admin/users/[userId]/role/route");
+          return PATCH(
+            new Request("http://localhost/api/v1/admin/users/user-1/role", {
+              method: "PATCH",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ role: "moderator" }),
+            }),
+            { params: Promise.resolve({ userId: "user-1" }) },
+          );
+        },
+      },
+      {
+        name: "POST /admin/offers",
+        run: async () => {
+          const { POST } = await import("@/app/api/v1/admin/offers/route");
+          return POST(
+            new Request("http://localhost/api/v1/admin/offers", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                variantId: "variant-1",
+                locationId: "loc-1",
+                sizeMl: 500,
+                serving: "tap",
+                priceCents: 555,
+              }),
+            }),
+          );
+        },
+      },
+    ];
+
+    it.each(adminCases)("rejects anonymous access to $name", async ({ run }) => {
+      const auth = await import("@/lib/auth");
+      mockedRequireAdminUser.mockRejectedValueOnce(new auth.UnauthorizedError());
+
+      const body = await expectUnauthorized(run);
+      expect(body.error.message).toBe("Authentication required.");
+    });
+
+    it.each(adminCases)("rejects non-admins from $name", async ({ run }) => {
+      const auth = await import("@/lib/auth");
+      mockedRequireAdminUser.mockRejectedValueOnce(new auth.ForbiddenError());
+
+      const body = await expectForbidden(run);
+      expect(body.error.message).toBe("Admin permissions required.");
+    });
+
+    it("allows admins to access user management lists", async () => {
+      mockedRequireAdminUser.mockResolvedValueOnce(adminUser);
+      mockedGetUsersForAdmin.mockResolvedValueOnce([{ id: "user-1" }]);
+
+      const { GET } = await import("@/app/api/v1/admin/users/route");
+      const response = await GET();
+      const body = await parseJson<{ status: string; data: { users: Array<{ id: string }> } }>(
+        response,
+      );
+
+      expect(response.status).toBe(200);
+      expect(body.status).toBe("ok");
+      expect(body.data.users[0]?.id).toBe("user-1");
+    });
+
+    it("allows admins to update roles", async () => {
+      mockedRequireAdminUser.mockResolvedValueOnce(adminUser);
+      mockedUpdateUserRoleByAdmin.mockResolvedValueOnce({
+        outcome: "updated",
+        user: { id: "user-1", role: "moderator" },
+      });
+
+      const { PATCH } = await import("@/app/api/v1/admin/users/[userId]/role/route");
+      const response = await PATCH(
+        new Request("http://localhost/api/v1/admin/users/user-1/role", {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ role: "moderator" }),
+        }),
+        { params: Promise.resolve({ userId: "user-1" }) },
+      );
+      const body = await parseJson<{
+        status: string;
+        data: { user: { id: string; role: string } };
+      }>(response);
+
+      expect(response.status).toBe(200);
+      expect(body.status).toBe("ok");
+      expect(body.data.user.role).toBe("moderator");
+      expect(mockedUpdateUserRoleByAdmin).toHaveBeenCalledWith({
+        targetUserId: "user-1",
+        role: "moderator",
+        actingAdminId: adminUser.id,
+      });
+    });
+
+    it("allows admins to create approved offers", async () => {
+      mockedRequireAdminUser.mockResolvedValueOnce(adminUser);
+      mockedCreateBeerOffer.mockResolvedValueOnce({
+        id: "offer-1",
+        brand: "Brand",
+        variant: "Variant",
+        sizeMl: 500,
+        priceEur: 5.55,
+      });
+      mockedLogModerationAction.mockResolvedValueOnce();
+
+      const { POST } = await import("@/app/api/v1/admin/offers/route");
+      const response = await POST(
+        new Request("http://localhost/api/v1/admin/offers", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            variantId: "variant-1",
+            locationId: "loc-1",
+            sizeMl: 500,
+            serving: "tap",
+            priceCents: 555,
+          }),
+        }),
+      );
+      const body = await parseJson<{ status: string; data: { offer: { id: string } } }>(response);
+
+      expect(response.status).toBe(201);
+      expect(body.status).toBe("ok");
+      expect(body.data.offer.id).toBe("offer-1");
+      expect(mockedLogModerationAction).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/__tests__/api/test-auth-links.route.test.ts
+++ b/__tests__/api/test-auth-links.route.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+import { captureTestEmail, clearCapturedTestEmails } from "@/lib/test-email";
+
+describe("POST /api/v1/test/auth-links", () => {
+  const originalE2ETestMode = process.env.E2E_TEST_MODE;
+
+  beforeEach(() => {
+    process.env.E2E_TEST_MODE = "true";
+    clearCapturedTestEmails();
+  });
+
+  afterEach(() => {
+    clearCapturedTestEmails();
+
+    if (originalE2ETestMode === undefined) {
+      delete process.env.E2E_TEST_MODE;
+      return;
+    }
+
+    process.env.E2E_TEST_MODE = originalE2ETestMode;
+  });
+
+  it("returns the latest captured verification email", async () => {
+    captureTestEmail({
+      kind: "verification",
+      to: "user@example.com",
+      subject: "Older verification email",
+      text: "older",
+      html: "<p>older</p>",
+      actionUrl: "http://localhost/api/v1/auth/verify-email?token=older",
+    });
+    captureTestEmail({
+      kind: "verification",
+      to: "user@example.com",
+      subject: "Latest verification email",
+      text: "latest",
+      html: "<p>latest</p>",
+      actionUrl: "http://localhost/api/v1/auth/verify-email?token=latest",
+    });
+
+    const { POST } = await import("@/app/api/v1/test/auth-links/route");
+    const response = await POST(
+      new Request("http://localhost/api/v1/test/auth-links", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kind: "verification", email: "USER@example.com" }),
+      }),
+    );
+    const body = (await response.json()) as {
+      status: string;
+      data: {
+        url: string;
+        email: {
+          kind: string;
+          to: string;
+          subject: string;
+        };
+      };
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.status).toBe("ok");
+    expect(body.data.url).toBe("http://localhost/api/v1/auth/verify-email?token=latest");
+    expect(body.data.email.kind).toBe("verification");
+    expect(body.data.email.to).toBe("user@example.com");
+    expect(body.data.email.subject).toBe("Latest verification email");
+  });
+
+  it("returns captured change-email verification emails", async () => {
+    captureTestEmail({
+      kind: "change_email_verification",
+      to: "new-email@example.com",
+      subject: "Confirm your new Kiel Beer Index email address",
+      text: "confirm",
+      html: "<p>confirm</p>",
+      actionUrl: "http://localhost/api/v1/auth/verify-email?token=change-email",
+    });
+
+    const { POST } = await import("@/app/api/v1/test/auth-links/route");
+    const response = await POST(
+      new Request("http://localhost/api/v1/test/auth-links", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          kind: "change_email_verification",
+          email: "new-email@example.com",
+        }),
+      }),
+    );
+    const body = (await response.json()) as {
+      status: string;
+      data: { url: string; email: { kind: string; subject: string } };
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.status).toBe("ok");
+    expect(body.data.url).toBe("http://localhost/api/v1/auth/verify-email?token=change-email");
+    expect(body.data.email.kind).toBe("change_email_verification");
+    expect(body.data.email.subject).toMatch(/confirm your new/i);
+  });
+
+  it("returns 404 when no captured auth email exists", async () => {
+    const { POST } = await import("@/app/api/v1/test/auth-links/route");
+    const response = await POST(
+      new Request("http://localhost/api/v1/test/auth-links", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kind: "verification", email: "missing@example.com" }),
+      }),
+    );
+    const body = (await response.json()) as { status: string; error: { code: string } };
+
+    expect(response.status).toBe(404);
+    expect(body.status).toBe("error");
+    expect(body.error.code).toBe("AUTH_EMAIL_NOT_FOUND");
+  });
+});

--- a/__tests__/lib/prisma-errors.test.ts
+++ b/__tests__/lib/prisma-errors.test.ts
@@ -30,6 +30,15 @@ describe("isPrismaErrorCode", () => {
     expect(isPrismaErrorCode(makeKnownError("P2002"), "P2002")).toBe(true);
   });
 
+  it("maps postgres unique violations from the driver adapter to P2002", () => {
+    expect(isPrismaErrorCode({ cause: { originalCode: "23505" } }, "P2002")).toBe(true);
+  });
+
+  it("maps postgres foreign key and restrict violations from the driver adapter to P2003", () => {
+    expect(isPrismaErrorCode({ cause: { originalCode: "23503" } }, "P2003")).toBe(true);
+    expect(isPrismaErrorCode({ cause: { originalCode: "23001" } }, "P2003")).toBe(true);
+  });
+
   it("returns false when the error has a different code", () => {
     expect(isPrismaErrorCode(makeKnownError("P2025"), "P2002")).toBe(false);
   });

--- a/e2e/admin-smoke.spec.ts
+++ b/e2e/admin-smoke.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Locator } from "@playwright/test";
 import {
   E2E_ADMIN_DISPLAY_NAME,
   E2E_ADMIN_EMAIL,
@@ -7,19 +7,22 @@ import {
   E2E_ADMIN_MANAGED_EMAIL,
   E2E_ADMIN_PASSWORD,
 } from "./global-setup";
+import { createE2ETestSuffix, signIn } from "./helpers";
 
-async function signIn(page: Page, email: string, password: string): Promise<void> {
-  await page.goto("/login");
-  await page.fill("#login-email", email);
-  await page.fill("#login-password", password);
-  await page.getByRole("button", { name: "Sign In" }).click();
-  await page.waitForURL("/");
+async function expandUserRow(row: Locator): Promise<void> {
+  const toggle = row.locator("button[aria-expanded]").first();
+
+  if ((await toggle.getAttribute("aria-expanded")) !== "true") {
+    await toggle.click();
+  }
+
+  await expect(toggle).toHaveAttribute("aria-expanded", "true");
 }
 
 test("admin management pages support core smoke actions across styles, brands, variants, locations, and users", async ({
   page,
 }, testInfo) => {
-  const suffix = `${testInfo.workerIndex}-${Date.now()}`;
+  const suffix = createE2ETestSuffix(testInfo);
   const styleName = `${E2E_ADMIN_ENTITY_PREFIX} Style ${suffix}`;
   const brandName = `${E2E_ADMIN_ENTITY_PREFIX} Brand ${suffix}`;
   const variantName = `${E2E_ADMIN_ENTITY_PREFIX} Variant ${suffix}`;
@@ -78,14 +81,16 @@ test("admin management pages support core smoke actions across styles, brands, v
 
   let managedUserRow = page.locator("li").filter({ hasText: E2E_ADMIN_MANAGED_EMAIL }).first();
   await expect(managedUserRow).toBeVisible();
-  await managedUserRow.locator("button[aria-expanded]").click();
+  await expandUserRow(managedUserRow);
+  await expect(managedUserRow.getByRole("button", { name: "Verify Email" })).toBeVisible();
   await managedUserRow.getByRole("button", { name: "Verify Email" }).click();
   await expect(page.getByText("User email verified.")).toBeVisible();
 
   await page.fill("#search-users", E2E_ADMIN_MANAGED_EMAIL);
   managedUserRow = page.locator("li").filter({ hasText: E2E_ADMIN_MANAGED_EMAIL }).first();
   await expect(managedUserRow).toContainText("verified");
-  await managedUserRow.locator("button[aria-expanded]").click();
+  await expandUserRow(managedUserRow);
+  await expect(managedUserRow.locator('select[id^="role-"]')).toBeVisible();
   await managedUserRow.locator(`select[id^="role-"]`).selectOption("moderator");
   await managedUserRow.getByRole("button", { name: "Save Role" }).click();
   await expect(page.getByText("User role updated.")).toBeVisible();

--- a/e2e/auth-recovery.spec.ts
+++ b/e2e/auth-recovery.spec.ts
@@ -1,24 +1,11 @@
-import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
+import { expect, test, type APIRequestContext } from "@playwright/test";
 import {
   E2E_REGISTER_FLOW_DISPLAY_NAME,
   E2E_REGISTER_FLOW_EMAIL,
   E2E_REGISTER_FLOW_NEW_PASSWORD,
   E2E_REGISTER_FLOW_PASSWORD,
 } from "./global-setup";
-
-async function signIn(page: Page, email: string, password: string): Promise<void> {
-  await page.goto("/login");
-  await page.fill("#login-email", email);
-  await page.fill("#login-password", password);
-  await page.getByRole("button", { name: "Sign In" }).click();
-  await page.waitForURL("/");
-}
-
-async function signOut(page: Page): Promise<void> {
-  const nav = page.getByRole("navigation", { name: "Site navigation" });
-  await nav.getByRole("button", { name: "Sign Out" }).click();
-  await expect(nav.getByRole("link", { name: "Sign In" })).toBeVisible();
-}
+import { signIn, signOut } from "./helpers";
 
 async function createAuthLink(
   request: APIRequestContext,

--- a/e2e/auth-recovery.spec.ts
+++ b/e2e/auth-recovery.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type APIRequestContext } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import {
   E2E_CHANGE_EMAIL_DISPLAY_NAME,
   E2E_CHANGE_EMAIL_EMAIL,
@@ -9,33 +9,7 @@ import {
   E2E_REGISTER_FLOW_NEW_PASSWORD,
   E2E_REGISTER_FLOW_PASSWORD,
 } from "./global-setup";
-import { signIn, signOut } from "./helpers";
-
-async function createAuthLink(
-  request: APIRequestContext,
-  kind: "verification" | "change_email_verification" | "password_reset",
-  email: string,
-): Promise<string> {
-  const deadline = Date.now() + 15000;
-
-  while (Date.now() < deadline) {
-    const response = await request.post("/api/v1/test/auth-links", {
-      data: { kind, email },
-    });
-
-    if (response.ok()) {
-      const body = (await response.json()) as { data?: { url?: string } };
-      const url = body.data?.url;
-
-      expect(url).toBeTruthy();
-      return url as string;
-    }
-
-    await new Promise((resolvePromise) => setTimeout(resolvePromise, 250));
-  }
-
-  throw new Error(`Timed out creating ${kind} auth link for ${email}.`);
-}
+import { getCapturedAuthLink, signIn, signOut } from "./helpers";
 
 test("user can register, verify email, request a password reset, and sign in with the new password", async ({
   page,
@@ -47,7 +21,11 @@ test("user can register, verify email, request a password reset, and sign in wit
   await page.fill("#register-password", E2E_REGISTER_FLOW_PASSWORD);
   await page.getByRole("button", { name: "Create Account" }).click();
 
-  const verificationUrl = await createAuthLink(request, "verification", E2E_REGISTER_FLOW_EMAIL);
+  const verificationUrl = await getCapturedAuthLink(
+    request,
+    "verification",
+    E2E_REGISTER_FLOW_EMAIL,
+  );
   await page.goto(verificationUrl);
   await page.waitForURL("/");
 
@@ -60,7 +38,7 @@ test("user can register, verify email, request a password reset, and sign in wit
   await page.fill("#forgot-email", E2E_REGISTER_FLOW_EMAIL);
   await page.getByRole("button", { name: "Send Reset Link" }).click();
 
-  const resetUrl = await createAuthLink(request, "password_reset", E2E_REGISTER_FLOW_EMAIL);
+  const resetUrl = await getCapturedAuthLink(request, "password_reset", E2E_REGISTER_FLOW_EMAIL);
   await page.goto(resetUrl);
   await expect(page.getByRole("heading", { name: "Set New Password" })).toBeVisible();
 
@@ -85,7 +63,7 @@ test("user can request and verify an email change", async ({ page, request }) =>
 
   await expect(page.getByRole("status")).toContainText(E2E_CHANGE_EMAIL_NEW_EMAIL);
 
-  const verificationUrl = await createAuthLink(
+  const verificationUrl = await getCapturedAuthLink(
     request,
     "change_email_verification",
     E2E_CHANGE_EMAIL_NEW_EMAIL,

--- a/e2e/auth-recovery.spec.ts
+++ b/e2e/auth-recovery.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test, type APIRequestContext } from "@playwright/test";
 import {
+  E2E_CHANGE_EMAIL_DISPLAY_NAME,
+  E2E_CHANGE_EMAIL_EMAIL,
+  E2E_CHANGE_EMAIL_NEW_EMAIL,
+  E2E_CHANGE_EMAIL_PASSWORD,
   E2E_REGISTER_FLOW_DISPLAY_NAME,
   E2E_REGISTER_FLOW_EMAIL,
   E2E_REGISTER_FLOW_NEW_PASSWORD,
@@ -9,7 +13,7 @@ import { signIn, signOut } from "./helpers";
 
 async function createAuthLink(
   request: APIRequestContext,
-  kind: "verification" | "password_reset",
+  kind: "verification" | "change_email_verification" | "password_reset",
   email: string,
 ): Promise<string> {
   const deadline = Date.now() + 15000;
@@ -67,4 +71,40 @@ test("user can register, verify email, request a password reset, and sign in wit
 
   await signIn(page, E2E_REGISTER_FLOW_EMAIL, E2E_REGISTER_FLOW_NEW_PASSWORD);
   await expect(nav.getByText(E2E_REGISTER_FLOW_DISPLAY_NAME)).toBeVisible();
+});
+
+test("user can request and verify an email change", async ({ page, request }) => {
+  await signIn(page, E2E_CHANGE_EMAIL_EMAIL, E2E_CHANGE_EMAIL_PASSWORD);
+  await page.goto("/profile");
+  await expect(page.getByRole("heading", { name: "Your Profile" })).toBeVisible();
+  await expect(page.locator("#profile-display-name")).toHaveValue(E2E_CHANGE_EMAIL_DISPLAY_NAME);
+
+  await page.fill("#profile-new-email", E2E_CHANGE_EMAIL_NEW_EMAIL);
+  await page.fill("#profile-email-password", E2E_CHANGE_EMAIL_PASSWORD);
+  await page.getByRole("button", { name: "Send Verification Email" }).click();
+
+  await expect(page.getByRole("status")).toContainText(E2E_CHANGE_EMAIL_NEW_EMAIL);
+
+  const verificationUrl = await createAuthLink(
+    request,
+    "change_email_verification",
+    E2E_CHANGE_EMAIL_NEW_EMAIL,
+  );
+
+  await page.goto(verificationUrl);
+  await page.waitForURL("/");
+
+  await page.goto("/profile");
+  const changeEmailSection = page.locator("section", {
+    has: page.getByRole("heading", { name: "Change Email" }),
+  });
+  await expect(changeEmailSection.getByText(E2E_CHANGE_EMAIL_NEW_EMAIL)).toBeVisible();
+
+  await signOut(page);
+  await signIn(page, E2E_CHANGE_EMAIL_NEW_EMAIL, E2E_CHANGE_EMAIL_PASSWORD);
+  await expect(
+    page
+      .getByRole("navigation", { name: "Site navigation" })
+      .getByText(E2E_CHANGE_EMAIL_DISPLAY_NAME),
+  ).toBeVisible();
 });

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -6,6 +6,7 @@ import {
   E2E_UNVERIFIED_EMAIL,
   E2E_UNVERIFIED_PASSWORD,
 } from "./global-setup";
+import { getCapturedAuthLink } from "./helpers";
 
 test.describe("auth lifecycle", () => {
   test("sign in with valid credentials shows user in nav and sign out returns to guest state", async ({
@@ -35,7 +36,10 @@ test.describe("auth lifecycle", () => {
     await expect(nav.getByRole("button", { name: "Sign Out" })).not.toBeVisible();
   });
 
-  test("login with unverified email surfaces a verification error", async ({ page }) => {
+  test("login with unverified email can recover via resend verification", async ({
+    page,
+    request,
+  }) => {
     await page.goto("/login");
 
     await page.fill("#login-email", E2E_UNVERIFIED_EMAIL);
@@ -51,6 +55,20 @@ test.describe("auth lifecycle", () => {
 
     // User should still be on the login page — no redirect occurred.
     await expect(page).toHaveURL(/\/login/);
+
+    await page.getByRole("button", { name: /resend verification/i }).click();
+    await expect(page.getByRole("status")).toContainText(/verification email resent/i);
+
+    const verificationUrl = await getCapturedAuthLink(
+      request,
+      "verification",
+      E2E_UNVERIFIED_EMAIL,
+    );
+    await page.goto(verificationUrl);
+    await page.waitForURL("/");
+
+    const nav = page.getByRole("navigation", { name: "Site navigation" });
+    await expect(nav.getByRole("button", { name: "Sign Out" })).toBeVisible();
   });
 
   test("login with wrong password shows an error and stays on login page", async ({ page }) => {

--- a/e2e/contribution-moderation.spec.ts
+++ b/e2e/contribution-moderation.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import {
   E2E_AUTH_EMAIL,
   E2E_AUTH_PASSWORD,
@@ -10,6 +10,7 @@ import {
   E2E_REPORTER_PASSWORD,
   E2E_REPORTER_DISPLAY_NAME,
 } from "./global-setup";
+import { createE2ETestSuffix, signIn, signOut } from "./helpers";
 
 const TEST_SIZE_ML = "777";
 const TEST_PRICE_CENTS = "49999";
@@ -18,20 +19,6 @@ const TEST_PRICE_LABEL = new Intl.NumberFormat("de-DE", {
   currency: "EUR",
   minimumFractionDigits: 2,
 }).format(Number(TEST_PRICE_CENTS) / 100);
-
-async function signIn(page: Page, email: string, password: string): Promise<void> {
-  await page.goto("/login");
-  await page.fill("#login-email", email);
-  await page.fill("#login-password", password);
-  await page.getByRole("button", { name: "Sign In" }).click();
-  await page.waitForURL("/");
-}
-
-async function signOut(page: Page): Promise<void> {
-  const nav = page.getByRole("navigation", { name: "Site navigation" });
-  await nav.getByRole("button", { name: "Sign Out" }).click();
-  await expect(nav.getByRole("link", { name: "Sign In" })).toBeVisible();
-}
 
 test("contributor can submit an offer and moderator can approve it into the public directory", async ({
   page,
@@ -91,7 +78,7 @@ test("contributor can submit an offer and moderator can approve it into the publ
 test("contributor can submit a location and later use it as an approved offer target", async ({
   page,
 }, testInfo) => {
-  const suffix = `${testInfo.workerIndex}-${Date.now()}`;
+  const suffix = createE2ETestSuffix(testInfo);
   const locationName = `E2E Harbor Pub ${suffix}`;
   const district = `Test District ${suffix}`;
   const address = `${suffix} Teststrasse 42`;
@@ -143,7 +130,7 @@ test("contributor can submit a location and later use it as an approved offer ta
 test("authenticated user can create, edit, and report a review that a moderator resolves", async ({
   page,
 }, testInfo) => {
-  const suffix = `${testInfo.workerIndex}-${Date.now()}`;
+  const suffix = createE2ETestSuffix(testInfo);
   const initialTitle = `E2E Review ${suffix}`;
   const initialBody = `Initial review body ${suffix}`;
   const updatedTitle = `Updated E2E Review ${suffix}`;

--- a/e2e/contribution-moderation.spec.ts
+++ b/e2e/contribution-moderation.spec.ts
@@ -20,6 +20,13 @@ const TEST_PRICE_LABEL = new Intl.NumberFormat("de-DE", {
   minimumFractionDigits: 2,
 }).format(Number(TEST_PRICE_CENTS) / 100);
 
+const EDITED_TEST_PRICE_EUR = "123.45";
+const EDITED_TEST_PRICE_LABEL = new Intl.NumberFormat("de-DE", {
+  style: "currency",
+  currency: "EUR",
+  minimumFractionDigits: 2,
+}).format(Number(EDITED_TEST_PRICE_EUR));
+
 test("contributor can submit an offer and moderator can approve it into the public directory", async ({
   page,
 }) => {
@@ -125,6 +132,65 @@ test("contributor can submit a location and later use it as an approved offer ta
   });
 
   await expect(approvedLocationOption).toHaveCount(1);
+});
+
+test("moderator can edit and reject a pending location submission", async ({ page }, testInfo) => {
+  const suffix = createE2ETestSuffix(testInfo);
+  const locationName = `E2E Reject Location ${suffix}`;
+  const district = `Reject District ${suffix}`;
+  const address = `${suffix} Rejectstrasse 42`;
+  const updatedDistrict = `Edited District ${suffix}`;
+  const updatedAddress = `${suffix} Editedstrasse 99`;
+
+  await signIn(page, E2E_AUTH_EMAIL, E2E_AUTH_PASSWORD);
+
+  await page.goto("/contribute");
+  await page.getByRole("tab", { name: "New Location" }).click();
+  await page.fill("#location-name", locationName);
+  await page.selectOption("#location-type", "pub");
+  await page.fill("#location-district", district);
+  await page.fill("#location-address", address);
+  await page.getByRole("button", { name: "Submit Location" }).click();
+  await expect(page.getByRole("status")).toContainText("Location submitted for moderation.");
+
+  await signOut(page);
+  await signIn(page, E2E_MODERATOR_EMAIL, E2E_MODERATOR_PASSWORD);
+
+  await page.goto("/moderation");
+  await page.getByRole("button", { name: /Locations \(/ }).click();
+
+  const pendingLocationItem = page
+    .locator("li")
+    .filter({ hasText: locationName })
+    .filter({ hasText: address })
+    .filter({ hasText: district });
+
+  await expect(pendingLocationItem).toHaveCount(1);
+  await pendingLocationItem.getByRole("button", { name: "Edit" }).click();
+  await pendingLocationItem.locator('input[placeholder="' + district + '"]').fill(updatedDistrict);
+  await pendingLocationItem.locator('input[placeholder="' + address + '"]').fill(updatedAddress);
+  await pendingLocationItem.getByRole("button", { name: "Save" }).click();
+
+  await expect(page.locator('p[role="status"]')).toContainText("Location updated.");
+
+  const editedLocationItem = page
+    .locator("li")
+    .filter({ hasText: locationName })
+    .filter({ hasText: updatedAddress })
+    .filter({ hasText: updatedDistrict });
+
+  await expect(editedLocationItem).toHaveCount(1);
+  await editedLocationItem.getByRole("button", { name: "Reject" }).click();
+  await expect(page.locator('p[role="status"]')).toContainText("location rejected.");
+  await expect(editedLocationItem).toHaveCount(0);
+
+  await signOut(page);
+  await signIn(page, E2E_AUTH_EMAIL, E2E_AUTH_PASSWORD);
+
+  await page.goto("/contribute");
+  await expect(
+    page.locator("#offer-location-id option", { hasText: `${locationName} - Pub (Pending)` }),
+  ).toHaveCount(0);
 });
 
 test("authenticated user can submit a brand and variant and use the pending variant in the offer form", async ({
@@ -270,4 +336,61 @@ test("authenticated user can create, edit, and report a review that a moderator 
     .first();
 
   await expect(resolvedReportItem).toBeVisible();
+});
+
+test("moderator can edit and delete a pending offer submission", async ({ page }) => {
+  await signIn(page, E2E_AUTH_EMAIL, E2E_AUTH_PASSWORD);
+
+  await page.goto("/contribute");
+  await expect(page.getByRole("heading", { name: "Contribute" })).toBeVisible();
+
+  const brandName =
+    (await page.locator("#offer-brand-id option:checked").textContent())?.trim() ?? "";
+  const variantLabel =
+    (await page.locator("#offer-variant-id option:checked").textContent())?.trim() ?? "";
+  const variantName = variantLabel.split(" (")[0] ?? "";
+  const offerSizeMl = "888";
+  const offerPriceCents = "43210";
+  const offerPriceLabel = new Intl.NumberFormat("de-DE", {
+    style: "currency",
+    currency: "EUR",
+    minimumFractionDigits: 2,
+  }).format(Number(offerPriceCents) / 100);
+
+  await page.fill("#offer-size-ml", offerSizeMl);
+  await page.selectOption("#offer-serving", "bottle");
+  await page.fill("#offer-price-cents", offerPriceCents);
+  await page.getByRole("button", { name: "Submit Offer / Price Update" }).click();
+  await expect(page.getByRole("status")).toContainText("Offer submission created for moderation.");
+
+  await signOut(page);
+  await signIn(page, E2E_MODERATOR_EMAIL, E2E_MODERATOR_PASSWORD);
+
+  await page.goto("/moderation");
+  await page.getByRole("button", { name: /Offers \(/ }).click();
+
+  const pendingOfferItem = page
+    .locator("li")
+    .filter({ hasText: `${brandName} ${variantName}` })
+    .filter({ hasText: `${offerSizeMl} ml` })
+    .filter({ hasText: offerPriceLabel });
+
+  await expect(pendingOfferItem).toHaveCount(1);
+  await pendingOfferItem.getByRole("button", { name: "Edit Price" }).click();
+  await pendingOfferItem.locator('input[placeholder="432.10"]').fill(EDITED_TEST_PRICE_EUR);
+  await pendingOfferItem.getByRole("button", { name: "Save" }).click();
+
+  await expect(page.locator('p[role="status"]')).toContainText("Offer price updated.");
+
+  const editedOfferItem = page
+    .locator("li")
+    .filter({ hasText: `${brandName} ${variantName}` })
+    .filter({ hasText: `${offerSizeMl} ml` })
+    .filter({ hasText: EDITED_TEST_PRICE_LABEL });
+
+  await expect(editedOfferItem).toHaveCount(1);
+  await editedOfferItem.getByRole("button", { name: "Delete" }).click();
+  await editedOfferItem.getByRole("button", { name: "Confirm Delete" }).click();
+  await expect(page.locator('p[role="status"]')).toContainText("offer deleted.");
+  await expect(editedOfferItem).toHaveCount(0);
 });

--- a/e2e/contribution-moderation.spec.ts
+++ b/e2e/contribution-moderation.spec.ts
@@ -127,6 +127,47 @@ test("contributor can submit a location and later use it as an approved offer ta
   await expect(approvedLocationOption).toHaveCount(1);
 });
 
+test("authenticated user can submit a brand and variant and use the pending variant in the offer form", async ({
+  page,
+}, testInfo) => {
+  const suffix = createE2ETestSuffix(testInfo);
+  const brandName = `E2E Brand ${suffix}`;
+  const variantName = `E2E Variant ${suffix}`;
+
+  await signIn(page, E2E_AUTH_EMAIL, E2E_AUTH_PASSWORD);
+
+  await page.goto("/contribute");
+  await expect(page.getByRole("heading", { name: "Contribute" })).toBeVisible();
+
+  await page.getByRole("tab", { name: "New Brand" }).click();
+  await page.fill("#brand-name", brandName);
+  await page.getByRole("button", { name: "Submit Brand" }).click();
+
+  await expect(page.getByRole("status")).toContainText("Beer brand submitted for moderation.");
+
+  await page.getByRole("tab", { name: "New Variant" }).click();
+  await expect(
+    page.locator("#variant-brand-id option", { hasText: `${brandName} (Pending)` }),
+  ).toHaveCount(1);
+
+  const selectedStyleLabel =
+    (await page.locator("#variant-style-id option:checked").textContent())?.trim() ?? "";
+
+  await page.fill("#variant-name", variantName);
+  await page.selectOption("#variant-brand-id", { label: `${brandName} (Pending)` });
+  await page.getByRole("button", { name: "Submit Variant" }).click();
+
+  await expect(page.getByRole("status")).toContainText("Beer variant submitted for moderation.");
+
+  await page.getByRole("tab", { name: "Submit Offer" }).click();
+  await page.selectOption("#offer-brand-id", { label: brandName });
+  await expect(
+    page
+      .locator("#offer-variant-id option")
+      .filter({ hasText: `${variantName} (${selectedStyleLabel}, Pending)` }),
+  ).toHaveCount(1);
+});
+
 test("authenticated user can create, edit, and report a review that a moderator resolves", async ({
   page,
 }, testInfo) => {

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -10,7 +10,7 @@ import "dotenv/config";
 import { spawn } from "node:child_process";
 import { randomBytes, scrypt as scryptCallback } from "node:crypto";
 import { promisify } from "node:util";
-import pg from "pg";
+import { cleanupTestData, createTestDatabasePool } from "../test/database-reset";
 
 const scrypt = promisify(scryptCallback);
 
@@ -86,31 +86,6 @@ async function seedBaselineData(): Promise<void> {
   });
 }
 
-async function cleanupE2EData(pool: pg.Pool): Promise<void> {
-  const adminSmokeLike = `${E2E_ADMIN_ENTITY_PREFIX}%`;
-
-  await pool.query(`DELETE FROM "Report" WHERE "reporterId" = ANY($1::text[])`, [E2E_USER_IDS]);
-  await pool.query(`DELETE FROM "ModerationAuditLog" WHERE "moderatorId" = ANY($1::text[])`, [
-    E2E_USER_IDS,
-  ]);
-  await pool.query(`DELETE FROM "Review" WHERE "userId" = ANY($1::text[])`, [E2E_USER_IDS]);
-  await pool.query(`DELETE FROM "PriceUpdateProposal" WHERE "createdById" = ANY($1::text[])`, [
-    E2E_USER_IDS,
-  ]);
-  await pool.query(`DELETE FROM "BeerOffer" WHERE "createdById" = ANY($1::text[])`, [E2E_USER_IDS]);
-  await pool.query(`DELETE FROM "BeerVariant" WHERE name LIKE $1`, [adminSmokeLike]);
-  await pool.query(`DELETE FROM "BeerVariant" WHERE "createdById" = ANY($1::text[])`, [
-    E2E_USER_IDS,
-  ]);
-  await pool.query(`DELETE FROM "BeerBrand" WHERE name LIKE $1`, [adminSmokeLike]);
-  await pool.query(`DELETE FROM "BeerBrand" WHERE "createdById" = ANY($1::text[])`, [E2E_USER_IDS]);
-  await pool.query(`DELETE FROM "Location" WHERE name LIKE $1`, [adminSmokeLike]);
-  await pool.query(`DELETE FROM "Location" WHERE "createdById" = ANY($1::text[])`, [E2E_USER_IDS]);
-  await pool.query(`DELETE FROM "BeerStyle" WHERE name LIKE $1`, [adminSmokeLike]);
-  await pool.query(`DELETE FROM "User" WHERE email = ANY($1::text[])`, [E2E_DYNAMIC_USER_EMAILS]);
-  await pool.query(`DELETE FROM "User" WHERE id = ANY($1::text[])`, [E2E_USER_IDS]);
-}
-
 async function hashPassword(password: string): Promise<string> {
   const salt = randomBytes(16).toString("hex");
   const derivedKey = (await scrypt(password, salt, 64)) as Buffer;
@@ -124,11 +99,15 @@ export default async function globalSetup(): Promise<void> {
     throw new Error("DATABASE_URL must be set before running E2E tests.");
   }
 
-  const pool = new pg.Pool({ connectionString });
+  const pool = createTestDatabasePool(connectionString);
 
   try {
     await seedBaselineData();
-    await cleanupE2EData(pool);
+    await cleanupTestData(pool, {
+      namePrefixes: [E2E_ADMIN_ENTITY_PREFIX],
+      userEmails: [...E2E_DYNAMIC_USER_EMAILS],
+      userIds: [...E2E_USER_IDS],
+    });
 
     const verifiedHash = await hashPassword(E2E_AUTH_PASSWORD);
     const unverifiedHash = await hashPassword(E2E_UNVERIFIED_PASSWORD);

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,12 +1,13 @@
 /**
- * Playwright global setup — seeds a verified test user with a known password
- * so that auth lifecycle specs can sign in without relying on email verification.
+ * Playwright global setup — seeds baseline domain data plus verified test users
+ * with known passwords so E2E specs do not depend on prior manual db:seed runs.
  *
  * Uses raw pg (no Prisma) to avoid path-alias resolution issues in the Playwright
  * test runner context. Implements the same scrypt hash format as src/lib/auth.ts.
  */
 
 import "dotenv/config";
+import { spawn } from "node:child_process";
 import { randomBytes, scrypt as scryptCallback } from "node:crypto";
 import { promisify } from "node:util";
 import pg from "pg";
@@ -61,6 +62,30 @@ export const E2E_USER_IDS = [
   E2E_REPORTER_USER_ID,
 ] as const;
 
+function npmCommand(): string {
+  return process.platform === "win32" ? "npm.cmd" : "npm";
+}
+
+async function seedBaselineData(): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(npmCommand(), ["run", "db:seed"], {
+      cwd: process.cwd(),
+      env: process.env,
+      stdio: "inherit",
+    });
+
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      reject(new Error(`db:seed exited with code ${code ?? "unknown"}.`));
+    });
+  });
+}
+
 async function cleanupE2EData(pool: pg.Pool): Promise<void> {
   const adminSmokeLike = `${E2E_ADMIN_ENTITY_PREFIX}%`;
 
@@ -102,6 +127,7 @@ export default async function globalSetup(): Promise<void> {
   const pool = new pg.Pool({ connectionString });
 
   try {
+    await seedBaselineData();
     await cleanupE2EData(pool);
 
     const verifiedHash = await hashPassword(E2E_AUTH_PASSWORD);

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -10,7 +10,7 @@ import "dotenv/config";
 import { spawn } from "node:child_process";
 import { randomBytes, scrypt as scryptCallback } from "node:crypto";
 import { promisify } from "node:util";
-import { cleanupTestData, createTestDatabasePool } from "../test/database-reset";
+import { cleanupTestData, createTestDatabasePool } from "../test";
 
 const scrypt = promisify(scryptCallback);
 

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -51,7 +51,16 @@ export const E2E_REGISTER_FLOW_DISPLAY_NAME = "E2E Registration Flow";
 export const E2E_REGISTER_FLOW_PASSWORD = "RegisterPass123";
 export const E2E_REGISTER_FLOW_NEW_PASSWORD = "RegisterPass456";
 
-export const E2E_DYNAMIC_USER_EMAILS = [E2E_REGISTER_FLOW_EMAIL] as const;
+export const E2E_CHANGE_EMAIL_USER_ID = "e2e-change-email-test-user";
+export const E2E_CHANGE_EMAIL_EMAIL = "e2e-change-email@example.com";
+export const E2E_CHANGE_EMAIL_NEW_EMAIL = "e2e-change-email-next@example.com";
+export const E2E_CHANGE_EMAIL_PASSWORD = "TestPass123!";
+export const E2E_CHANGE_EMAIL_DISPLAY_NAME = "E2E Change Email";
+
+export const E2E_DYNAMIC_USER_EMAILS = [
+  E2E_REGISTER_FLOW_EMAIL,
+  E2E_CHANGE_EMAIL_NEW_EMAIL,
+] as const;
 
 export const E2E_USER_IDS = [
   E2E_AUTH_USER_ID,
@@ -60,6 +69,7 @@ export const E2E_USER_IDS = [
   E2E_ADMIN_USER_ID,
   E2E_ADMIN_MANAGED_USER_ID,
   E2E_REPORTER_USER_ID,
+  E2E_CHANGE_EMAIL_USER_ID,
 ] as const;
 
 function npmCommand(): string {
@@ -115,6 +125,7 @@ export default async function globalSetup(): Promise<void> {
     const adminHash = await hashPassword(E2E_ADMIN_PASSWORD);
     const managedUserHash = await hashPassword(E2E_ADMIN_MANAGED_PASSWORD);
     const reporterHash = await hashPassword(E2E_REPORTER_PASSWORD);
+    const changeEmailHash = await hashPassword(E2E_CHANGE_EMAIL_PASSWORD);
 
     // Verified user — can sign in immediately.
     await pool.query(
@@ -157,6 +168,17 @@ export default async function globalSetup(): Promise<void> {
       `INSERT INTO "User" (id, email, "displayName", role, "passwordHash", "emailVerified", "isBanned", "createdAt", "updatedAt")
        VALUES ($1, $2, $3, 'user', $4, true, false, NOW(), NOW())`,
       [E2E_REPORTER_USER_ID, E2E_REPORTER_EMAIL, E2E_REPORTER_DISPLAY_NAME, reporterHash],
+    );
+
+    await pool.query(
+      `INSERT INTO "User" (id, email, "displayName", role, "passwordHash", "emailVerified", "isBanned", "createdAt", "updatedAt")
+       VALUES ($1, $2, $3, 'user', $4, true, false, NOW(), NOW())`,
+      [
+        E2E_CHANGE_EMAIL_USER_ID,
+        E2E_CHANGE_EMAIL_EMAIL,
+        E2E_CHANGE_EMAIL_DISPLAY_NAME,
+        changeEmailHash,
+      ],
     );
   } finally {
     await pool.end();

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,19 @@
+import { expect, type Page, type TestInfo } from "@playwright/test";
+
+export async function signIn(page: Page, email: string, password: string): Promise<void> {
+  await page.goto("/login");
+  await page.fill("#login-email", email);
+  await page.fill("#login-password", password);
+  await page.getByRole("button", { name: "Sign In" }).click();
+  await page.waitForURL("/");
+}
+
+export async function signOut(page: Page): Promise<void> {
+  const nav = page.getByRole("navigation", { name: "Site navigation" });
+  await nav.getByRole("button", { name: "Sign Out" }).click();
+  await expect(nav.getByRole("link", { name: "Sign In" })).toBeVisible();
+}
+
+export function createE2ETestSuffix(testInfo: TestInfo): string {
+  return `${testInfo.workerIndex}-${Date.now()}`;
+}

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,4 +1,4 @@
-import { expect, type Page, type TestInfo } from "@playwright/test";
+import { expect, type APIRequestContext, type Page, type TestInfo } from "@playwright/test";
 
 export async function signIn(page: Page, email: string, password: string): Promise<void> {
   await page.goto("/login");
@@ -12,6 +12,32 @@ export async function signOut(page: Page): Promise<void> {
   const nav = page.getByRole("navigation", { name: "Site navigation" });
   await nav.getByRole("button", { name: "Sign Out" }).click();
   await expect(nav.getByRole("link", { name: "Sign In" })).toBeVisible();
+}
+
+export async function getCapturedAuthLink(
+  request: APIRequestContext,
+  kind: "verification" | "change_email_verification" | "password_reset",
+  email: string,
+): Promise<string> {
+  const deadline = Date.now() + 15000;
+
+  while (Date.now() < deadline) {
+    const response = await request.post("/api/v1/test/auth-links", {
+      data: { kind, email },
+    });
+
+    if (response.ok()) {
+      const body = (await response.json()) as { data?: { url?: string } };
+      const url = body.data?.url;
+
+      expect(url).toBeTruthy();
+      return url as string;
+    }
+
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 250));
+  }
+
+  throw new Error(`Timed out finding captured ${kind} auth link for ${email}.`);
 }
 
 export function createE2ETestSuffix(testInfo: TestInfo): string {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,7 @@ const eslintConfig = defineConfig([
     ".next/**",
     "out/**",
     "build/**",
+    "coverage/**",
     "next-env.d.ts",
   ]),
 ]);

--- a/integration-tests/auth.ts
+++ b/integration-tests/auth.ts
@@ -1,0 +1,508 @@
+import { createHash } from "node:crypto";
+import { db } from "@/lib/db";
+import {
+  createEmailVerificationToken,
+  hashPassword,
+  requestEmailChange,
+  requestPasswordReset,
+  resetPassword,
+  updateDisplayName,
+  updatePassword,
+  verifyEmailToken,
+  verifyPassword,
+} from "@/lib/auth";
+import { buildUser, type TestNamespace } from "../test/factories";
+import { assert, runIntegrationTest } from "./helpers";
+
+type IntegrationCheck = {
+  name: string;
+  fn: () => Promise<void>;
+};
+
+type SeedAuthUserOptions = {
+  id?: string;
+  email?: string;
+  displayName?: string;
+  role?: "user" | "moderator" | "admin";
+  emailVerified?: boolean;
+  isBanned?: boolean;
+  pendingEmail?: string | null;
+  password?: string;
+};
+
+async function seedAuthUser(
+  namespace: TestNamespace,
+  label: string,
+  options: SeedAuthUserOptions = {},
+): Promise<{ user: ReturnType<typeof buildUser>; password: string }> {
+  const password = options.password ?? "Password123!";
+  const user = buildUser(namespace, label, {
+    ...(options.id !== undefined ? { id: options.id } : {}),
+    ...(options.email !== undefined ? { email: options.email } : {}),
+    ...(options.displayName !== undefined ? { displayName: options.displayName } : {}),
+    ...(options.role !== undefined ? { role: options.role } : {}),
+    emailVerified: options.emailVerified ?? true,
+    isBanned: options.isBanned ?? false,
+    passwordHash: await hashPassword(password),
+  });
+
+  await db.user.create({
+    data: {
+      ...user,
+      pendingEmail: options.pendingEmail ?? null,
+    },
+  });
+
+  return { user, password };
+}
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+async function testUpdateDisplayNamePersistsNormalizedValue(): Promise<void> {
+  await runIntegrationTest("update-display-name", async ({ namespace }) => {
+    const { user } = await seedAuthUser(namespace, "display-name");
+
+    const updated = await updateDisplayName(user.id, "  Updated Display Name  ");
+    const stored = await db.user.findUnique({
+      where: { id: user.id },
+      select: { displayName: true },
+    });
+
+    assert(updated.displayName === "Updated Display Name", "Expected display name to be trimmed.");
+    assert(
+      stored?.displayName === "Updated Display Name",
+      "Expected trimmed display name to persist in the database.",
+    );
+  });
+}
+
+async function testUpdatePasswordRejectsWrongCurrentPassword(): Promise<void> {
+  await runIntegrationTest("update-password-wrong-current", async ({ namespace }) => {
+    const { user, password } = await seedAuthUser(namespace, "wrong-current-password");
+    const before = await db.user.findUnique({
+      where: { id: user.id },
+      select: { passwordHash: true },
+    });
+
+    const result = await updatePassword(user.id, "WrongPassword123!", "NewPassword456!");
+    const after = await db.user.findUnique({
+      where: { id: user.id },
+      select: { passwordHash: true },
+    });
+
+    assert(!result.ok, "Expected wrong current password to be rejected.");
+    assert(
+      before?.passwordHash === after?.passwordHash,
+      "Expected password hash to remain unchanged when validation fails.",
+    );
+    if (!after?.passwordHash) {
+      fail("Expected password hash to remain available after a failed password update.");
+    }
+
+    assert(
+      await verifyPassword(password, after.passwordHash),
+      "Expected the original password to remain valid.",
+    );
+  });
+}
+
+async function testUpdatePasswordReplacesStoredHash(): Promise<void> {
+  await runIntegrationTest("update-password-success", async ({ namespace }) => {
+    const { user, password } = await seedAuthUser(namespace, "update-password-success");
+    const newPassword = "NewPassword456!";
+
+    const result = await updatePassword(user.id, password, newPassword);
+    const stored = await db.user.findUnique({
+      where: { id: user.id },
+      select: { passwordHash: true },
+    });
+
+    assert(result.ok, "Expected password update to succeed.");
+    if (!stored?.passwordHash) {
+      fail("Expected updated user to keep a password hash.");
+    }
+
+    assert(
+      !(await verifyPassword(password, stored.passwordHash)),
+      "Expected the old password to stop working after replacement.",
+    );
+    assert(
+      await verifyPassword(newPassword, stored.passwordHash),
+      "Expected the new password to verify successfully.",
+    );
+  });
+}
+
+async function testRequestEmailChangeValidatesPasswordAndEmailState(): Promise<void> {
+  await runIntegrationTest("request-email-change-validation", async ({ namespace }) => {
+    const { user, password } = await seedAuthUser(namespace, "email-change-user", {
+      email: namespace.email("current-email"),
+    });
+    const takenEmail = namespace.email("taken-email");
+
+    await seedAuthUser(namespace, "email-taken-user", { email: takenEmail });
+
+    const sameEmail = await requestEmailChange(user.id, user.email, password);
+    const wrongPassword = await requestEmailChange(
+      user.id,
+      namespace.email("new-email"),
+      "wrong-password",
+    );
+    const taken = await requestEmailChange(user.id, takenEmail, password);
+    const stored = await db.user.findUnique({
+      where: { id: user.id },
+      select: { pendingEmail: true },
+    });
+
+    assert(
+      !sameEmail.ok && sameEmail.code === "SAME_EMAIL",
+      "Expected same-email changes to be blocked.",
+    );
+    assert(
+      !wrongPassword.ok && wrongPassword.code === "WRONG_PASSWORD",
+      "Expected email changes to require the current password.",
+    );
+    assert(
+      !taken.ok && taken.code === "EMAIL_TAKEN",
+      "Expected already-claimed emails to be blocked.",
+    );
+    assert(
+      stored?.pendingEmail === null,
+      "Expected invalid email change requests to leave pendingEmail empty.",
+    );
+  });
+}
+
+async function testVerifyEmailTokenMarksNewUserVerified(): Promise<void> {
+  await runIntegrationTest("verify-email-token-registration", async ({ namespace }) => {
+    const { user } = await seedAuthUser(namespace, "verify-registration-user", {
+      emailVerified: false,
+    });
+    const token = await createEmailVerificationToken(user.id);
+
+    const result = await verifyEmailToken(token);
+    const stored = await db.user.findUnique({
+      where: { id: user.id },
+      select: { emailVerified: true },
+    });
+    const remainingTokens = await db.emailVerificationToken.count({ where: { userId: user.id } });
+
+    assert(result.ok, "Expected a valid verification token to succeed.");
+    assert(
+      stored?.emailVerified === true,
+      "Expected email verification to mark the user verified.",
+    );
+    assert(remainingTokens === 0, "Expected verification tokens to be deleted after use.");
+  });
+}
+
+async function testEmailChangeRequestAndVerificationFlow(): Promise<void> {
+  await runIntegrationTest("email-change-verification-flow", async ({ namespace }) => {
+    const { user, password } = await seedAuthUser(namespace, "email-change-flow", {
+      email: namespace.email("before-change"),
+    });
+    const nextEmail = namespace.email("after-change");
+
+    const changeRequest = await requestEmailChange(user.id, nextEmail, password);
+    const beforeVerification = await db.user.findUnique({
+      where: { id: user.id },
+      select: { email: true, pendingEmail: true, emailVerified: true },
+    });
+
+    assert(changeRequest.ok, "Expected a valid email change request to succeed.");
+    if (!changeRequest.ok) {
+      fail("Expected a valid email change request to produce a verification token.");
+    }
+
+    assert(
+      beforeVerification?.email === user.email,
+      "Expected the current email to stay unchanged until verification completes.",
+    );
+    assert(
+      beforeVerification?.pendingEmail === nextEmail,
+      "Expected the requested email to be stored as pendingEmail.",
+    );
+
+    const verification = await verifyEmailToken(changeRequest.token);
+    const afterVerification = await db.user.findUnique({
+      where: { id: user.id },
+      select: { email: true, pendingEmail: true, emailVerified: true },
+    });
+
+    assert(verification.ok, "Expected email change verification to succeed.");
+    assert(
+      afterVerification?.email === nextEmail,
+      "Expected verification to promote pendingEmail to email.",
+    );
+    assert(
+      afterVerification?.pendingEmail === null,
+      "Expected pendingEmail to be cleared after verification.",
+    );
+    assert(
+      afterVerification?.emailVerified === true,
+      "Expected the email to remain verified after change.",
+    );
+  });
+}
+
+async function testExpiredEmailVerificationTokenIsRejectedAndDeleted(): Promise<void> {
+  await runIntegrationTest("verify-email-token-expired", async ({ namespace }) => {
+    const { user } = await seedAuthUser(namespace, "expired-email-token", {
+      emailVerified: false,
+    });
+    const token = await createEmailVerificationToken(user.id);
+    const tokenHash = createHash("sha256").update(token).digest("hex");
+
+    await db.emailVerificationToken.update({
+      where: { tokenHash },
+      data: { expiresAt: new Date(Date.now() - 60_000) },
+    });
+
+    const result = await verifyEmailToken(token);
+    const stored = await db.user.findUnique({
+      where: { id: user.id },
+      select: { emailVerified: true },
+    });
+    const tokenRecord = await db.emailVerificationToken.findUnique({ where: { tokenHash } });
+
+    assert(
+      !result.ok && result.reason === "expired",
+      "Expected expired email tokens to be rejected.",
+    );
+    assert(stored?.emailVerified === false, "Expected expired tokens not to verify the user.");
+    assert(tokenRecord === null, "Expected expired email tokens to be deleted after rejection.");
+  });
+}
+
+async function testEmailChangeVerificationConflictClearsPendingEmail(): Promise<void> {
+  await runIntegrationTest("verify-email-token-conflict", async ({ namespace }) => {
+    const { user, password } = await seedAuthUser(namespace, "email-conflict-owner", {
+      email: namespace.email("original-owner"),
+    });
+    const claimedEmail = namespace.email("claimed-during-flow");
+    const changeRequest = await requestEmailChange(user.id, claimedEmail, password);
+
+    assert(changeRequest.ok, "Expected the initial email change request to succeed.");
+    if (!changeRequest.ok) {
+      fail("Expected the initial email change request to produce a verification token.");
+    }
+
+    await seedAuthUser(namespace, "email-conflict-claimer", {
+      email: claimedEmail,
+      emailVerified: true,
+    });
+
+    const verification = await verifyEmailToken(changeRequest.token);
+    const stored = await db.user.findUnique({
+      where: { id: user.id },
+      select: { email: true, pendingEmail: true },
+    });
+    const remainingTokens = await db.emailVerificationToken.count({ where: { userId: user.id } });
+
+    assert(
+      !verification.ok && verification.reason === "email_conflict",
+      "Expected verification to fail if another account claims the target email first.",
+    );
+    assert(
+      stored?.email === user.email,
+      "Expected the original email to remain unchanged on conflict.",
+    );
+    assert(stored?.pendingEmail === null, "Expected pendingEmail to be cleared after a conflict.");
+    assert(remainingTokens === 0, "Expected the conflicting verification token to be deleted.");
+  });
+}
+
+async function testRequestPasswordResetOnlyCreatesActiveUserTokens(): Promise<void> {
+  await runIntegrationTest("request-password-reset", async ({ namespace }) => {
+    const { user: activeUser } = await seedAuthUser(namespace, "reset-active", {
+      email: namespace.email("reset-active"),
+      emailVerified: true,
+      isBanned: false,
+    });
+    const { user: unverifiedUser } = await seedAuthUser(namespace, "reset-unverified", {
+      email: namespace.email("reset-unverified"),
+      emailVerified: false,
+    });
+    const { user: bannedUser } = await seedAuthUser(namespace, "reset-banned", {
+      email: namespace.email("reset-banned"),
+      emailVerified: true,
+      isBanned: true,
+    });
+
+    const missing = await requestPasswordReset(namespace.email("missing-user"));
+    const unverified = await requestPasswordReset(unverifiedUser.email);
+    const banned = await requestPasswordReset(bannedUser.email);
+    const first = await requestPasswordReset(activeUser.email);
+    const second = await requestPasswordReset(activeUser.email);
+
+    assert(
+      !missing.ok && missing.reason === "USER_NOT_FOUND",
+      "Expected unknown users to be rejected.",
+    );
+    assert(
+      !unverified.ok && unverified.reason === "USER_NOT_FOUND",
+      "Expected unverified users not to receive password reset tokens.",
+    );
+    assert(
+      !banned.ok && banned.reason === "USER_NOT_FOUND",
+      "Expected banned users not to receive reset tokens.",
+    );
+    assert(first.ok, "Expected active verified users to receive reset tokens.");
+    assert(second.ok, "Expected repeated password reset requests to remain valid.");
+    if (!first.ok || !second.ok) {
+      fail("Expected active verified users to receive password reset tokens.");
+    }
+
+    const tokenCount = await db.passwordResetToken.count({ where: { userId: activeUser.id } });
+    const firstTokenHash = createHash("sha256").update(first.token).digest("hex");
+    const firstTokenRecord = await db.passwordResetToken.findUnique({
+      where: { tokenHash: firstTokenHash },
+    });
+
+    assert(tokenCount === 1, "Expected repeated reset requests to keep only one active token.");
+    assert(
+      firstTokenRecord === null,
+      "Expected a newer password reset request to invalidate the older token.",
+    );
+  });
+}
+
+async function testResetPasswordRejectsInvalidAndExpiredTokens(): Promise<void> {
+  await runIntegrationTest("reset-password-invalid-expired", async ({ namespace }) => {
+    const { user } = await seedAuthUser(namespace, "reset-invalid-expired", {
+      emailVerified: true,
+    });
+    const token = await requestPasswordReset(user.email);
+
+    assert(token.ok, "Expected a reset token to be issued for an active verified user.");
+    if (!token.ok) {
+      fail("Expected a reset token to be issued for an active verified user.");
+    }
+
+    const invalid = await resetPassword("not-a-real-token", "NewPassword456!");
+    const tokenHash = createHash("sha256").update(token.token).digest("hex");
+
+    await db.passwordResetToken.update({
+      where: { tokenHash },
+      data: { expiresAt: new Date(Date.now() - 60_000) },
+    });
+
+    const expired = await resetPassword(token.token, "NewPassword456!");
+    const expiredTokenRecord = await db.passwordResetToken.findUnique({ where: { tokenHash } });
+
+    assert(
+      !invalid.ok && invalid.reason === "invalid",
+      "Expected unknown reset tokens to be rejected.",
+    );
+    assert(
+      !expired.ok && expired.reason === "expired",
+      "Expected expired reset tokens to be rejected.",
+    );
+    assert(
+      expiredTokenRecord === null,
+      "Expected expired reset tokens to be deleted after rejection.",
+    );
+  });
+}
+
+async function testResetPasswordReplacesPasswordAndInvalidatesSessions(): Promise<void> {
+  await runIntegrationTest("reset-password-success", async ({ namespace }) => {
+    const { user, password } = await seedAuthUser(namespace, "reset-password-success", {
+      emailVerified: true,
+    });
+    const request = await requestPasswordReset(user.email);
+
+    assert(request.ok, "Expected a password reset token to be issued.");
+    if (!request.ok) {
+      fail("Expected a password reset token to be issued.");
+    }
+
+    await db.session.createMany({
+      data: [
+        {
+          userId: user.id,
+          tokenHash: namespace.id("session-one"),
+          expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        },
+        {
+          userId: user.id,
+          tokenHash: namespace.id("session-two"),
+          expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        },
+      ],
+    });
+
+    const result = await resetPassword(request.token, "BrandNewPassword789!");
+    const stored = await db.user.findUnique({
+      where: { id: user.id },
+      select: { passwordHash: true },
+    });
+    const sessionCount = await db.session.count({ where: { userId: user.id } });
+    const tokenCount = await db.passwordResetToken.count({ where: { userId: user.id } });
+
+    assert(result.ok, "Expected a valid reset token to update the password.");
+    if (!stored?.passwordHash) {
+      fail("Expected password reset to leave a password hash in place.");
+    }
+
+    assert(
+      !(await verifyPassword(password, stored.passwordHash)),
+      "Expected password reset to invalidate the previous password.",
+    );
+    assert(
+      await verifyPassword("BrandNewPassword789!", stored.passwordHash),
+      "Expected password reset to store the replacement password.",
+    );
+    assert(sessionCount === 0, "Expected password reset to invalidate all active sessions.");
+    assert(tokenCount === 0, "Expected password reset to delete all outstanding reset tokens.");
+  });
+}
+
+export const authIntegrationChecks: IntegrationCheck[] = [
+  {
+    name: "updateDisplayName persists normalized display names",
+    fn: testUpdateDisplayNamePersistsNormalizedValue,
+  },
+  {
+    name: "updatePassword rejects the wrong current password",
+    fn: testUpdatePasswordRejectsWrongCurrentPassword,
+  },
+  {
+    name: "updatePassword replaces the stored password hash",
+    fn: testUpdatePasswordReplacesStoredHash,
+  },
+  {
+    name: "requestEmailChange validates password and target email state",
+    fn: testRequestEmailChangeValidatesPasswordAndEmailState,
+  },
+  {
+    name: "verifyEmailToken marks new users verified",
+    fn: testVerifyEmailTokenMarksNewUserVerified,
+  },
+  {
+    name: "requestEmailChange and verifyEmailToken complete the email change flow",
+    fn: testEmailChangeRequestAndVerificationFlow,
+  },
+  {
+    name: "verifyEmailToken rejects and deletes expired tokens",
+    fn: testExpiredEmailVerificationTokenIsRejectedAndDeleted,
+  },
+  {
+    name: "verifyEmailToken clears pendingEmail on email conflicts",
+    fn: testEmailChangeVerificationConflictClearsPendingEmail,
+  },
+  {
+    name: "requestPasswordReset only issues tokens for active verified users",
+    fn: testRequestPasswordResetOnlyCreatesActiveUserTokens,
+  },
+  {
+    name: "resetPassword rejects invalid and expired tokens",
+    fn: testResetPasswordRejectsInvalidAndExpiredTokens,
+  },
+  {
+    name: "resetPassword replaces the password and invalidates sessions",
+    fn: testResetPasswordReplacesPasswordAndInvalidatesSessions,
+  },
+];

--- a/integration-tests/auth.ts
+++ b/integration-tests/auth.ts
@@ -2,7 +2,6 @@ import { createHash } from "node:crypto";
 import { db } from "@/lib/db";
 import {
   createEmailVerificationToken,
-  hashPassword,
   requestEmailChange,
   requestPasswordReset,
   resetPassword,
@@ -11,54 +10,12 @@ import {
   verifyEmailToken,
   verifyPassword,
 } from "@/lib/auth";
-import { buildUser, type TestNamespace } from "../test/factories";
-import { assert, runIntegrationTest } from "./helpers";
+import { assert, fail, runIntegrationTest, seedAuthUser } from "./helpers";
 
 type IntegrationCheck = {
   name: string;
   fn: () => Promise<void>;
 };
-
-type SeedAuthUserOptions = {
-  id?: string;
-  email?: string;
-  displayName?: string;
-  role?: "user" | "moderator" | "admin";
-  emailVerified?: boolean;
-  isBanned?: boolean;
-  pendingEmail?: string | null;
-  password?: string;
-};
-
-async function seedAuthUser(
-  namespace: TestNamespace,
-  label: string,
-  options: SeedAuthUserOptions = {},
-): Promise<{ user: ReturnType<typeof buildUser>; password: string }> {
-  const password = options.password ?? "Password123!";
-  const user = buildUser(namespace, label, {
-    ...(options.id !== undefined ? { id: options.id } : {}),
-    ...(options.email !== undefined ? { email: options.email } : {}),
-    ...(options.displayName !== undefined ? { displayName: options.displayName } : {}),
-    ...(options.role !== undefined ? { role: options.role } : {}),
-    emailVerified: options.emailVerified ?? true,
-    isBanned: options.isBanned ?? false,
-    passwordHash: await hashPassword(password),
-  });
-
-  await db.user.create({
-    data: {
-      ...user,
-      pendingEmail: options.pendingEmail ?? null,
-    },
-  });
-
-  return { user, password };
-}
-
-function fail(message: string): never {
-  throw new Error(message);
-}
 
 async function testUpdateDisplayNamePersistsNormalizedValue(): Promise<void> {
   await runIntegrationTest("update-display-name", async ({ namespace }) => {

--- a/integration-tests/helpers.ts
+++ b/integration-tests/helpers.ts
@@ -1,10 +1,17 @@
 import { db } from "@/lib/db";
 import { clearCurrentSession, createSession, hashPassword } from "@/lib/auth";
-import { cleanupTestData, createTestDatabasePool } from "../test/database-reset";
-import { createTestNamespace, type TestNamespace } from "../test/factories";
-import { buildCatalogFixture, buildUser } from "../test/factories";
+import {
+  buildCatalogFixture,
+  buildUser,
+  cleanupTestData,
+  createTestDatabasePool,
+  createTestNamespace,
+  type TestNamespace,
+} from "../test";
 
 const resetPool = createTestDatabasePool();
+
+type CatalogFixtureOverrides = NonNullable<Parameters<typeof buildCatalogFixture>[2]>;
 
 export function assert(condition: unknown, message: string): void {
   if (!condition) {
@@ -72,7 +79,7 @@ export async function closeIntegrationTestResources(): Promise<void> {
 export async function seedCatalogFixture(
   namespace: TestNamespace,
   label: string,
-  overrides: Parameters<typeof buildCatalogFixture>[2] = {},
+  overrides: CatalogFixtureOverrides = {},
 ) {
   const fixture = buildCatalogFixture(namespace, label, overrides);
 
@@ -86,6 +93,28 @@ export async function seedCatalogFixture(
   }
 
   return fixture;
+}
+
+export async function seedCatalogOfferFixture(
+  namespace: TestNamespace,
+  label: string,
+  overrides: Omit<CatalogFixtureOverrides, "offer"> & {
+    offer?: Exclude<CatalogFixtureOverrides["offer"], false | undefined>;
+  } = {},
+) {
+  const fixture = await seedCatalogFixture(namespace, label, {
+    ...overrides,
+    offer: overrides.offer ?? {},
+  });
+
+  if (!fixture.offer) {
+    throw new Error("Expected catalog fixture to include an offer.");
+  }
+
+  return {
+    ...fixture,
+    offer: fixture.offer,
+  };
 }
 
 export async function runIntegrationTest(

--- a/integration-tests/helpers.ts
+++ b/integration-tests/helpers.ts
@@ -1,10 +1,58 @@
 import { db } from "@/lib/db";
+import { clearCurrentSession, createSession, hashPassword } from "@/lib/auth";
 import { createTestNamespace, type TestNamespace } from "../test/factories";
+import { buildUser } from "../test/factories";
 
 export function assert(condition: unknown, message: string): void {
   if (!condition) {
     throw new Error(message);
   }
+}
+
+export function fail(message: string): never {
+  throw new Error(message);
+}
+
+type SeedAuthUserOptions = {
+  id?: string;
+  email?: string;
+  displayName?: string;
+  role?: "user" | "moderator" | "admin";
+  emailVerified?: boolean;
+  isBanned?: boolean;
+  pendingEmail?: string | null;
+  password?: string;
+};
+
+export async function seedAuthUser(
+  namespace: TestNamespace,
+  label: string,
+  options: SeedAuthUserOptions = {},
+): Promise<{ user: ReturnType<typeof buildUser>; password: string }> {
+  const password = options.password ?? "Password123!";
+  const user = buildUser(namespace, label, {
+    ...(options.id !== undefined ? { id: options.id } : {}),
+    ...(options.email !== undefined ? { email: options.email } : {}),
+    ...(options.displayName !== undefined ? { displayName: options.displayName } : {}),
+    ...(options.role !== undefined ? { role: options.role } : {}),
+    emailVerified: options.emailVerified ?? true,
+    isBanned: options.isBanned ?? false,
+    passwordHash: await hashPassword(password),
+  });
+
+  await db.user.create({
+    data: {
+      ...user,
+      pendingEmail: options.pendingEmail ?? null,
+    },
+  });
+
+  return { user, password };
+}
+
+export async function startAuthenticatedSession(userId: string): Promise<void> {
+  await clearCurrentSession();
+  await createSession(userId);
 }
 
 export async function cleanupIntegrationData(prefix: string): Promise<void> {
@@ -124,11 +172,13 @@ export async function runIntegrationTest(
 ): Promise<void> {
   const namespace = createTestNamespace(name);
 
+  await clearCurrentSession();
   await cleanupIntegrationData(namespace.prefix);
 
   try {
     await fn({ namespace });
   } finally {
+    await clearCurrentSession();
     await cleanupIntegrationData(namespace.prefix);
   }
 }

--- a/integration-tests/helpers.ts
+++ b/integration-tests/helpers.ts
@@ -1,7 +1,10 @@
 import { db } from "@/lib/db";
 import { clearCurrentSession, createSession, hashPassword } from "@/lib/auth";
+import { cleanupTestData, createTestDatabasePool } from "../test/database-reset";
 import { createTestNamespace, type TestNamespace } from "../test/factories";
-import { buildUser } from "../test/factories";
+import { buildCatalogFixture, buildUser } from "../test/factories";
+
+const resetPool = createTestDatabasePool();
 
 export function assert(condition: unknown, message: string): void {
   if (!condition) {
@@ -56,114 +59,33 @@ export async function startAuthenticatedSession(userId: string): Promise<void> {
 }
 
 export async function cleanupIntegrationData(prefix: string): Promise<void> {
-  await db.report.deleteMany({
-    where: {
-      OR: [
-        { contentId: { startsWith: prefix } },
-        { reporterId: { startsWith: prefix } },
-        { resolvedById: { startsWith: prefix } },
-        { snapshotAuthorId: { startsWith: prefix } },
-      ],
-    },
+  await cleanupTestData(resetPool, {
+    idPrefixes: [prefix],
+    namePrefixes: [prefix],
   });
+}
 
-  await db.moderationAuditLog.deleteMany({
-    where: {
-      OR: [
-        { contentId: { startsWith: prefix } },
-        { moderatorId: { startsWith: prefix } },
-        { moderatorName: { startsWith: prefix } },
-      ],
-    },
-  });
+export async function closeIntegrationTestResources(): Promise<void> {
+  await resetPool.end();
+}
 
-  await db.review.deleteMany({
-    where: {
-      OR: [
-        { id: { startsWith: prefix } },
-        { locationId: { startsWith: prefix } },
-        { userId: { startsWith: prefix } },
-      ],
-    },
-  });
+export async function seedCatalogFixture(
+  namespace: TestNamespace,
+  label: string,
+  overrides: Parameters<typeof buildCatalogFixture>[2] = {},
+) {
+  const fixture = buildCatalogFixture(namespace, label, overrides);
 
-  await db.offerPriceHistory.deleteMany({
-    where: {
-      OR: [
-        { id: { startsWith: prefix } },
-        { beerOfferId: { startsWith: prefix } },
-        { priceUpdateProposalId: { startsWith: prefix } },
-      ],
-    },
-  });
+  await db.beerStyle.create({ data: fixture.style });
+  await db.beerBrand.create({ data: fixture.brand });
+  await db.beerVariant.create({ data: fixture.variant });
+  await db.location.create({ data: fixture.location });
 
-  await db.priceUpdateProposal.deleteMany({
-    where: {
-      OR: [
-        { id: { startsWith: prefix } },
-        { beerOfferId: { startsWith: prefix } },
-        { createdById: { startsWith: prefix } },
-      ],
-    },
-  });
+  if (fixture.offer) {
+    await db.beerOffer.create({ data: fixture.offer });
+  }
 
-  await db.beerOffer.deleteMany({
-    where: {
-      OR: [
-        { id: { startsWith: prefix } },
-        { locationId: { startsWith: prefix } },
-        { variantId: { startsWith: prefix } },
-        { createdById: { startsWith: prefix } },
-      ],
-    },
-  });
-
-  await db.beerVariant.deleteMany({
-    where: {
-      OR: [
-        { id: { startsWith: prefix } },
-        { brandId: { startsWith: prefix } },
-        { styleId: { startsWith: prefix } },
-        { createdById: { startsWith: prefix } },
-      ],
-    },
-  });
-
-  await db.beerBrand.deleteMany({
-    where: {
-      OR: [
-        { id: { startsWith: prefix } },
-        { name: { startsWith: prefix } },
-        { createdById: { startsWith: prefix } },
-      ],
-    },
-  });
-
-  await db.beerStyle.deleteMany({
-    where: {
-      OR: [{ id: { startsWith: prefix } }, { name: { startsWith: prefix } }],
-    },
-  });
-
-  await db.location.deleteMany({
-    where: {
-      OR: [
-        { id: { startsWith: prefix } },
-        { name: { startsWith: prefix } },
-        { createdById: { startsWith: prefix } },
-      ],
-    },
-  });
-
-  await db.user.deleteMany({
-    where: {
-      OR: [
-        { id: { startsWith: prefix } },
-        { email: { startsWith: prefix } },
-        { displayName: { startsWith: prefix } },
-      ],
-    },
-  });
+  return fixture;
 }
 
 export async function runIntegrationTest(

--- a/integration-tests/register-server-only.mjs
+++ b/integration-tests/register-server-only.mjs
@@ -1,0 +1,36 @@
+import Module from "node:module";
+
+const cookieValues = new Map();
+const originalLoad = Module._load;
+
+async function cookies() {
+  return {
+    get(name) {
+      const value = cookieValues.get(name);
+
+      if (!value) {
+        return undefined;
+      }
+
+      return { name, value };
+    },
+    set(name, value) {
+      cookieValues.set(name, value);
+    },
+    delete(name) {
+      cookieValues.delete(name);
+    },
+  };
+}
+
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === "server-only") {
+    return {};
+  }
+
+  if (request === "next/headers") {
+    return { cookies };
+  }
+
+  return originalLoad.call(this, request, parent, isMain);
+};

--- a/integration-tests/routes.ts
+++ b/integration-tests/routes.ts
@@ -1,15 +1,11 @@
 import { db } from "@/lib/db";
-import {
-  buildBeerBrand,
-  buildBeerOffer,
-  buildBeerStyle,
-  buildBeerVariant,
-  buildLocation,
-} from "../test/factories";
+import { buildBeerBrand, buildBeerVariant } from "../test";
 import {
   assert,
   fail,
   runIntegrationTest,
+  seedCatalogFixture,
+  seedCatalogOfferFixture,
   seedAuthUser,
   startAuthenticatedSession,
 } from "./helpers";
@@ -80,25 +76,7 @@ async function testAdminBrandEditDuplicateMapsConflict(): Promise<void> {
 async function testAdminBrandDeleteInUseMapsConflict(): Promise<void> {
   await runIntegrationTest("admin-brand-delete-in-use", async ({ namespace }) => {
     const { user: admin } = await seedAuthUser(namespace, "admin-brand-delete", { role: "admin" });
-    const style = buildBeerStyle(namespace, "brand-delete-style");
-    const brand = buildBeerBrand(namespace, "brand-delete-brand");
-    const variant = buildBeerVariant(namespace, "brand-delete-variant", {
-      brandId: brand.id,
-      styleId: style.id,
-    });
-    const location = buildLocation(namespace, "brand-delete-location");
-    const offer = buildBeerOffer(namespace, "brand-delete-offer", {
-      brand: brand.name,
-      variant: variant.name,
-      variantId: variant.id,
-      locationId: location.id,
-    });
-
-    await db.beerStyle.create({ data: style });
-    await db.beerBrand.create({ data: brand });
-    await db.beerVariant.create({ data: variant });
-    await db.location.create({ data: location });
-    await db.beerOffer.create({ data: offer });
+    const { brand } = await seedCatalogOfferFixture(namespace, "brand delete");
     await startAuthenticatedSession(admin.id);
 
     const { DELETE } = await import("@/app/api/v1/admin/brands/[brandId]/route");
@@ -120,16 +98,9 @@ async function testAdminVariantCreateDuplicateMapsConflict(): Promise<void> {
     const { user: admin } = await seedAuthUser(namespace, "admin-variant-create", {
       role: "admin",
     });
-    const style = buildBeerStyle(namespace, "variant-create-style");
-    const brand = buildBeerBrand(namespace, "variant-create-brand");
-    const variant = buildBeerVariant(namespace, "variant-create-existing", {
-      brandId: brand.id,
-      styleId: style.id,
+    const { style, brand, variant } = await seedCatalogFixture(namespace, "variant create", {
+      offer: false,
     });
-
-    await db.beerStyle.create({ data: style });
-    await db.beerBrand.create({ data: brand });
-    await db.beerVariant.create({ data: variant });
     await startAuthenticatedSession(admin.id);
 
     const { POST } = await import("@/app/api/v1/admin/variants/route");
@@ -153,20 +124,16 @@ async function testAdminVariantCreateDuplicateMapsConflict(): Promise<void> {
 async function testAdminVariantEditDuplicateMapsConflict(): Promise<void> {
   await runIntegrationTest("admin-variant-edit-duplicate", async ({ namespace }) => {
     const { user: admin } = await seedAuthUser(namespace, "admin-variant-edit", { role: "admin" });
-    const style = buildBeerStyle(namespace, "variant-edit-style");
-    const brand = buildBeerBrand(namespace, "variant-edit-brand");
-    const originalVariant = buildBeerVariant(namespace, "variant-edit-original", {
-      brandId: brand.id,
-      styleId: style.id,
-    });
+    const {
+      style,
+      brand,
+      variant: originalVariant,
+    } = await seedCatalogFixture(namespace, "variant edit original", { offer: false });
     const duplicateVariant = buildBeerVariant(namespace, "variant-edit-duplicate", {
       brandId: brand.id,
       styleId: style.id,
     });
-
-    await db.beerStyle.create({ data: style });
-    await db.beerBrand.create({ data: brand });
-    await db.beerVariant.createMany({ data: [originalVariant, duplicateVariant] });
+    await db.beerVariant.create({ data: duplicateVariant });
     await startAuthenticatedSession(admin.id);
 
     const { PUT } = await import("@/app/api/v1/admin/variants/[variantId]/route");
@@ -193,25 +160,7 @@ async function testAdminVariantDeleteInUseMapsConflict(): Promise<void> {
     const { user: admin } = await seedAuthUser(namespace, "admin-variant-delete", {
       role: "admin",
     });
-    const style = buildBeerStyle(namespace, "variant-delete-style");
-    const brand = buildBeerBrand(namespace, "variant-delete-brand");
-    const variant = buildBeerVariant(namespace, "variant-delete-variant", {
-      brandId: brand.id,
-      styleId: style.id,
-    });
-    const location = buildLocation(namespace, "variant-delete-location");
-    const offer = buildBeerOffer(namespace, "variant-delete-offer", {
-      brand: brand.name,
-      variant: variant.name,
-      variantId: variant.id,
-      locationId: location.id,
-    });
-
-    await db.beerStyle.create({ data: style });
-    await db.beerBrand.create({ data: brand });
-    await db.beerVariant.create({ data: variant });
-    await db.location.create({ data: location });
-    await db.beerOffer.create({ data: offer });
+    const { variant } = await seedCatalogOfferFixture(namespace, "variant delete");
     await startAuthenticatedSession(admin.id);
 
     const { DELETE } = await import("@/app/api/v1/admin/variants/[variantId]/route");
@@ -232,16 +181,7 @@ async function testAdminVariantDeleteInUseMapsConflict(): Promise<void> {
 async function testAdminStyleDeleteInUseMapsConflict(): Promise<void> {
   await runIntegrationTest("admin-style-delete-in-use", async ({ namespace }) => {
     const { user: admin } = await seedAuthUser(namespace, "admin-style-delete", { role: "admin" });
-    const style = buildBeerStyle(namespace, "style-delete-style");
-    const brand = buildBeerBrand(namespace, "style-delete-brand");
-    const variant = buildBeerVariant(namespace, "style-delete-variant", {
-      brandId: brand.id,
-      styleId: style.id,
-    });
-
-    await db.beerStyle.create({ data: style });
-    await db.beerBrand.create({ data: brand });
-    await db.beerVariant.create({ data: variant });
+    const { style } = await seedCatalogFixture(namespace, "style delete", { offer: false });
     await startAuthenticatedSession(admin.id);
 
     const { DELETE } = await import("@/app/api/v1/admin/styles/[styleId]/route");
@@ -261,27 +201,9 @@ async function testAdminStyleDeleteInUseMapsConflict(): Promise<void> {
 async function testAdminOfferCreateDuplicateMapsConflict(): Promise<void> {
   await runIntegrationTest("admin-offer-create-duplicate", async ({ namespace }) => {
     const { user: admin } = await seedAuthUser(namespace, "admin-offer-create", { role: "admin" });
-    const style = buildBeerStyle(namespace, "offer-create-style");
-    const brand = buildBeerBrand(namespace, "offer-create-brand");
-    const variant = buildBeerVariant(namespace, "offer-create-variant", {
-      brandId: brand.id,
-      styleId: style.id,
+    const { variant, location } = await seedCatalogOfferFixture(namespace, "offer create", {
+      offer: { sizeMl: 500, serving: "tap" },
     });
-    const location = buildLocation(namespace, "offer-create-location");
-    const offer = buildBeerOffer(namespace, "offer-create-existing", {
-      brand: brand.name,
-      variant: variant.name,
-      variantId: variant.id,
-      locationId: location.id,
-      sizeMl: 500,
-      serving: "tap",
-    });
-
-    await db.beerStyle.create({ data: style });
-    await db.beerBrand.create({ data: brand });
-    await db.beerVariant.create({ data: variant });
-    await db.location.create({ data: location });
-    await db.beerOffer.create({ data: offer });
     await startAuthenticatedSession(admin.id);
 
     const { POST } = await import("@/app/api/v1/admin/offers/route");
@@ -313,26 +235,9 @@ async function testModerationOfferEditCreatesAuditLogEntry(): Promise<void> {
     const { user: moderator } = await seedAuthUser(namespace, "moderation-offer-edit", {
       role: "moderator",
     });
-    const style = buildBeerStyle(namespace, "moderation-edit-style");
-    const brand = buildBeerBrand(namespace, "moderation-edit-brand");
-    const variant = buildBeerVariant(namespace, "moderation-edit-variant", {
-      brandId: brand.id,
-      styleId: style.id,
+    const { offer } = await seedCatalogOfferFixture(namespace, "moderation edit", {
+      offer: { priceCents: 450 },
     });
-    const location = buildLocation(namespace, "moderation-edit-location");
-    const offer = buildBeerOffer(namespace, "moderation-edit-offer", {
-      brand: brand.name,
-      variant: variant.name,
-      variantId: variant.id,
-      locationId: location.id,
-      priceCents: 450,
-    });
-
-    await db.beerStyle.create({ data: style });
-    await db.beerBrand.create({ data: brand });
-    await db.beerVariant.create({ data: variant });
-    await db.location.create({ data: location });
-    await db.beerOffer.create({ data: offer });
     await startAuthenticatedSession(moderator.id);
 
     const { PUT } = await import("@/app/api/v1/moderation/offers/[offerId]/route");
@@ -385,27 +290,13 @@ async function testModerationOfferApproveCreatesAuditLogEntry(): Promise<void> {
     const { user: moderator } = await seedAuthUser(namespace, "moderation-offer-approve", {
       role: "moderator",
     });
-    const style = buildBeerStyle(namespace, "moderation-approve-style");
-    const brand = buildBeerBrand(namespace, "moderation-approve-brand");
-    const variant = buildBeerVariant(namespace, "moderation-approve-variant", {
-      brandId: brand.id,
-      styleId: style.id,
-    });
-    const location = buildLocation(namespace, "moderation-approve-location");
-    const offer = buildBeerOffer(namespace, "moderation-approve-offer", {
-      brand: brand.name,
-      variant: variant.name,
-      variantId: variant.id,
-      locationId: location.id,
-      priceCents: 495,
-      status: "pending",
-    });
-
-    await db.beerStyle.create({ data: style });
-    await db.beerBrand.create({ data: brand });
-    await db.beerVariant.create({ data: variant });
-    await db.location.create({ data: location });
-    await db.beerOffer.create({ data: offer });
+    const { variant, location, offer } = await seedCatalogOfferFixture(
+      namespace,
+      "moderation approve",
+      {
+        offer: { priceCents: 495, status: "pending" },
+      },
+    );
     await startAuthenticatedSession(moderator.id);
 
     const { PATCH } = await import("@/app/api/v1/moderation/offers/[offerId]/route");
@@ -470,27 +361,9 @@ async function testModerationOfferRejectCreatesAuditLogEntry(): Promise<void> {
     const { user: moderator } = await seedAuthUser(namespace, "moderation-offer-reject", {
       role: "moderator",
     });
-    const style = buildBeerStyle(namespace, "moderation-reject-style");
-    const brand = buildBeerBrand(namespace, "moderation-reject-brand");
-    const variant = buildBeerVariant(namespace, "moderation-reject-variant", {
-      brandId: brand.id,
-      styleId: style.id,
+    const { brand, offer } = await seedCatalogOfferFixture(namespace, "moderation reject", {
+      offer: { priceCents: 510, status: "pending" },
     });
-    const location = buildLocation(namespace, "moderation-reject-location");
-    const offer = buildBeerOffer(namespace, "moderation-reject-offer", {
-      brand: brand.name,
-      variant: variant.name,
-      variantId: variant.id,
-      locationId: location.id,
-      priceCents: 510,
-      status: "pending",
-    });
-
-    await db.beerStyle.create({ data: style });
-    await db.beerBrand.create({ data: brand });
-    await db.beerVariant.create({ data: variant });
-    await db.location.create({ data: location });
-    await db.beerOffer.create({ data: offer });
     await startAuthenticatedSession(moderator.id);
 
     const { PATCH } = await import("@/app/api/v1/moderation/offers/[offerId]/route");
@@ -555,26 +428,13 @@ async function testModerationOfferDeleteCreatesAuditLogEntry(): Promise<void> {
     const { user: moderator } = await seedAuthUser(namespace, "moderation-offer-delete", {
       role: "moderator",
     });
-    const style = buildBeerStyle(namespace, "moderation-delete-style");
-    const brand = buildBeerBrand(namespace, "moderation-delete-brand");
-    const variant = buildBeerVariant(namespace, "moderation-delete-variant", {
-      brandId: brand.id,
-      styleId: style.id,
-    });
-    const location = buildLocation(namespace, "moderation-delete-location");
-    const offer = buildBeerOffer(namespace, "moderation-delete-offer", {
-      brand: brand.name,
-      variant: variant.name,
-      variantId: variant.id,
-      locationId: location.id,
-      priceCents: 480,
-    });
-
-    await db.beerStyle.create({ data: style });
-    await db.beerBrand.create({ data: brand });
-    await db.beerVariant.create({ data: variant });
-    await db.location.create({ data: location });
-    await db.beerOffer.create({ data: offer });
+    const { variant, location, offer } = await seedCatalogOfferFixture(
+      namespace,
+      "moderation delete",
+      {
+        offer: { priceCents: 480 },
+      },
+    );
     await startAuthenticatedSession(moderator.id);
 
     const { DELETE } = await import("@/app/api/v1/moderation/offers/[offerId]/route");

--- a/integration-tests/routes.ts
+++ b/integration-tests/routes.ts
@@ -1,0 +1,491 @@
+import { db } from "@/lib/db";
+import {
+  buildBeerBrand,
+  buildBeerOffer,
+  buildBeerStyle,
+  buildBeerVariant,
+  buildLocation,
+} from "../test/factories";
+import {
+  assert,
+  fail,
+  runIntegrationTest,
+  seedAuthUser,
+  startAuthenticatedSession,
+} from "./helpers";
+
+type IntegrationCheck = {
+  name: string;
+  fn: () => Promise<void>;
+};
+
+async function parseJson(response: Response): Promise<unknown> {
+  return response.json();
+}
+
+async function testAdminBrandCreateDuplicateMapsConflict(): Promise<void> {
+  await runIntegrationTest("admin-brand-create-duplicate", async ({ namespace }) => {
+    const { user: admin } = await seedAuthUser(namespace, "admin-brand-create", { role: "admin" });
+    const brand = buildBeerBrand(namespace, "brand-create-duplicate");
+
+    await db.beerBrand.create({ data: brand });
+    await startAuthenticatedSession(admin.id);
+
+    const { POST } = await import("@/app/api/v1/admin/brands/route");
+    const response = await POST(
+      new Request("http://localhost/api/v1/admin/brands", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: brand.name }),
+      }),
+    );
+    const body = (await parseJson(response)) as { error?: { code?: string } };
+
+    assert(response.status === 409, "Expected duplicate admin brand creates to return 409.");
+    assert(
+      body.error?.code === "BRAND_NAME_CONFLICT",
+      "Expected duplicate admin brand creates to map to BRAND_NAME_CONFLICT.",
+    );
+  });
+}
+
+async function testAdminBrandEditDuplicateMapsConflict(): Promise<void> {
+  await runIntegrationTest("admin-brand-edit-duplicate", async ({ namespace }) => {
+    const { user: admin } = await seedAuthUser(namespace, "admin-brand-edit", { role: "admin" });
+    const originalBrand = buildBeerBrand(namespace, "brand-edit-original");
+    const duplicateBrand = buildBeerBrand(namespace, "brand-edit-duplicate");
+
+    await db.beerBrand.createMany({ data: [originalBrand, duplicateBrand] });
+    await startAuthenticatedSession(admin.id);
+
+    const { PUT } = await import("@/app/api/v1/admin/brands/[brandId]/route");
+    const response = await PUT(
+      new Request(`http://localhost/api/v1/admin/brands/${originalBrand.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: duplicateBrand.name }),
+      }),
+      { params: Promise.resolve({ brandId: originalBrand.id }) },
+    );
+    const body = (await parseJson(response)) as { error?: { code?: string } };
+
+    assert(response.status === 409, "Expected duplicate admin brand edits to return 409.");
+    assert(
+      body.error?.code === "BRAND_NAME_CONFLICT",
+      "Expected duplicate admin brand edits to map to BRAND_NAME_CONFLICT.",
+    );
+  });
+}
+
+async function testAdminBrandDeleteInUseMapsConflict(): Promise<void> {
+  await runIntegrationTest("admin-brand-delete-in-use", async ({ namespace }) => {
+    const { user: admin } = await seedAuthUser(namespace, "admin-brand-delete", { role: "admin" });
+    const style = buildBeerStyle(namespace, "brand-delete-style");
+    const brand = buildBeerBrand(namespace, "brand-delete-brand");
+    const variant = buildBeerVariant(namespace, "brand-delete-variant", {
+      brandId: brand.id,
+      styleId: style.id,
+    });
+    const location = buildLocation(namespace, "brand-delete-location");
+    const offer = buildBeerOffer(namespace, "brand-delete-offer", {
+      brand: brand.name,
+      variant: variant.name,
+      variantId: variant.id,
+      locationId: location.id,
+    });
+
+    await db.beerStyle.create({ data: style });
+    await db.beerBrand.create({ data: brand });
+    await db.beerVariant.create({ data: variant });
+    await db.location.create({ data: location });
+    await db.beerOffer.create({ data: offer });
+    await startAuthenticatedSession(admin.id);
+
+    const { DELETE } = await import("@/app/api/v1/admin/brands/[brandId]/route");
+    const response = await DELETE(new Request(`http://localhost/api/v1/admin/brands/${brand.id}`), {
+      params: Promise.resolve({ brandId: brand.id }),
+    });
+    const body = (await parseJson(response)) as { error?: { code?: string } };
+
+    assert(response.status === 409, "Expected in-use admin brand deletes to return 409.");
+    assert(
+      body.error?.code === "BRAND_IN_USE",
+      "Expected in-use admin brand deletes to map to BRAND_IN_USE.",
+    );
+  });
+}
+
+async function testAdminVariantCreateDuplicateMapsConflict(): Promise<void> {
+  await runIntegrationTest("admin-variant-create-duplicate", async ({ namespace }) => {
+    const { user: admin } = await seedAuthUser(namespace, "admin-variant-create", {
+      role: "admin",
+    });
+    const style = buildBeerStyle(namespace, "variant-create-style");
+    const brand = buildBeerBrand(namespace, "variant-create-brand");
+    const variant = buildBeerVariant(namespace, "variant-create-existing", {
+      brandId: brand.id,
+      styleId: style.id,
+    });
+
+    await db.beerStyle.create({ data: style });
+    await db.beerBrand.create({ data: brand });
+    await db.beerVariant.create({ data: variant });
+    await startAuthenticatedSession(admin.id);
+
+    const { POST } = await import("@/app/api/v1/admin/variants/route");
+    const response = await POST(
+      new Request("http://localhost/api/v1/admin/variants", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: variant.name, brandId: brand.id, styleId: style.id }),
+      }),
+    );
+    const body = (await parseJson(response)) as { error?: { code?: string } };
+
+    assert(response.status === 409, "Expected duplicate admin variant creates to return 409.");
+    assert(
+      body.error?.code === "VARIANT_NAME_CONFLICT",
+      "Expected duplicate admin variant creates to map to VARIANT_NAME_CONFLICT.",
+    );
+  });
+}
+
+async function testAdminVariantEditDuplicateMapsConflict(): Promise<void> {
+  await runIntegrationTest("admin-variant-edit-duplicate", async ({ namespace }) => {
+    const { user: admin } = await seedAuthUser(namespace, "admin-variant-edit", { role: "admin" });
+    const style = buildBeerStyle(namespace, "variant-edit-style");
+    const brand = buildBeerBrand(namespace, "variant-edit-brand");
+    const originalVariant = buildBeerVariant(namespace, "variant-edit-original", {
+      brandId: brand.id,
+      styleId: style.id,
+    });
+    const duplicateVariant = buildBeerVariant(namespace, "variant-edit-duplicate", {
+      brandId: brand.id,
+      styleId: style.id,
+    });
+
+    await db.beerStyle.create({ data: style });
+    await db.beerBrand.create({ data: brand });
+    await db.beerVariant.createMany({ data: [originalVariant, duplicateVariant] });
+    await startAuthenticatedSession(admin.id);
+
+    const { PUT } = await import("@/app/api/v1/admin/variants/[variantId]/route");
+    const response = await PUT(
+      new Request(`http://localhost/api/v1/admin/variants/${originalVariant.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: duplicateVariant.name }),
+      }),
+      { params: Promise.resolve({ variantId: originalVariant.id }) },
+    );
+    const body = (await parseJson(response)) as { error?: { code?: string } };
+
+    assert(response.status === 409, "Expected duplicate admin variant edits to return 409.");
+    assert(
+      body.error?.code === "VARIANT_NAME_CONFLICT",
+      "Expected duplicate admin variant edits to map to VARIANT_NAME_CONFLICT.",
+    );
+  });
+}
+
+async function testAdminVariantDeleteInUseMapsConflict(): Promise<void> {
+  await runIntegrationTest("admin-variant-delete-in-use", async ({ namespace }) => {
+    const { user: admin } = await seedAuthUser(namespace, "admin-variant-delete", {
+      role: "admin",
+    });
+    const style = buildBeerStyle(namespace, "variant-delete-style");
+    const brand = buildBeerBrand(namespace, "variant-delete-brand");
+    const variant = buildBeerVariant(namespace, "variant-delete-variant", {
+      brandId: brand.id,
+      styleId: style.id,
+    });
+    const location = buildLocation(namespace, "variant-delete-location");
+    const offer = buildBeerOffer(namespace, "variant-delete-offer", {
+      brand: brand.name,
+      variant: variant.name,
+      variantId: variant.id,
+      locationId: location.id,
+    });
+
+    await db.beerStyle.create({ data: style });
+    await db.beerBrand.create({ data: brand });
+    await db.beerVariant.create({ data: variant });
+    await db.location.create({ data: location });
+    await db.beerOffer.create({ data: offer });
+    await startAuthenticatedSession(admin.id);
+
+    const { DELETE } = await import("@/app/api/v1/admin/variants/[variantId]/route");
+    const response = await DELETE(
+      new Request(`http://localhost/api/v1/admin/variants/${variant.id}`),
+      { params: Promise.resolve({ variantId: variant.id }) },
+    );
+    const body = (await parseJson(response)) as { error?: { code?: string } };
+
+    assert(response.status === 409, "Expected in-use admin variant deletes to return 409.");
+    assert(
+      body.error?.code === "VARIANT_IN_USE",
+      "Expected in-use admin variant deletes to map to VARIANT_IN_USE.",
+    );
+  });
+}
+
+async function testAdminStyleDeleteInUseMapsConflict(): Promise<void> {
+  await runIntegrationTest("admin-style-delete-in-use", async ({ namespace }) => {
+    const { user: admin } = await seedAuthUser(namespace, "admin-style-delete", { role: "admin" });
+    const style = buildBeerStyle(namespace, "style-delete-style");
+    const brand = buildBeerBrand(namespace, "style-delete-brand");
+    const variant = buildBeerVariant(namespace, "style-delete-variant", {
+      brandId: brand.id,
+      styleId: style.id,
+    });
+
+    await db.beerStyle.create({ data: style });
+    await db.beerBrand.create({ data: brand });
+    await db.beerVariant.create({ data: variant });
+    await startAuthenticatedSession(admin.id);
+
+    const { DELETE } = await import("@/app/api/v1/admin/styles/[styleId]/route");
+    const response = await DELETE(new Request(`http://localhost/api/v1/admin/styles/${style.id}`), {
+      params: Promise.resolve({ styleId: style.id }),
+    });
+    const body = (await parseJson(response)) as { error?: { code?: string } };
+
+    assert(response.status === 409, "Expected in-use admin style deletes to return 409.");
+    assert(
+      body.error?.code === "STYLE_IN_USE",
+      "Expected in-use admin style deletes to map to STYLE_IN_USE.",
+    );
+  });
+}
+
+async function testAdminOfferCreateDuplicateMapsConflict(): Promise<void> {
+  await runIntegrationTest("admin-offer-create-duplicate", async ({ namespace }) => {
+    const { user: admin } = await seedAuthUser(namespace, "admin-offer-create", { role: "admin" });
+    const style = buildBeerStyle(namespace, "offer-create-style");
+    const brand = buildBeerBrand(namespace, "offer-create-brand");
+    const variant = buildBeerVariant(namespace, "offer-create-variant", {
+      brandId: brand.id,
+      styleId: style.id,
+    });
+    const location = buildLocation(namespace, "offer-create-location");
+    const offer = buildBeerOffer(namespace, "offer-create-existing", {
+      brand: brand.name,
+      variant: variant.name,
+      variantId: variant.id,
+      locationId: location.id,
+      sizeMl: 500,
+      serving: "tap",
+    });
+
+    await db.beerStyle.create({ data: style });
+    await db.beerBrand.create({ data: brand });
+    await db.beerVariant.create({ data: variant });
+    await db.location.create({ data: location });
+    await db.beerOffer.create({ data: offer });
+    await startAuthenticatedSession(admin.id);
+
+    const { POST } = await import("@/app/api/v1/admin/offers/route");
+    const response = await POST(
+      new Request("http://localhost/api/v1/admin/offers", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          variantId: variant.id,
+          locationId: location.id,
+          sizeMl: 500,
+          serving: "tap",
+          priceCents: 555,
+        }),
+      }),
+    );
+    const body = (await parseJson(response)) as { error?: { code?: string } };
+
+    assert(response.status === 409, "Expected duplicate admin offer creates to return 409.");
+    assert(
+      body.error?.code === "OFFER_CONFLICT",
+      "Expected duplicate admin offer creates to map to OFFER_CONFLICT.",
+    );
+  });
+}
+
+async function testModerationOfferEditCreatesAuditLogEntry(): Promise<void> {
+  await runIntegrationTest("moderation-offer-edit-audit-log", async ({ namespace }) => {
+    const { user: moderator } = await seedAuthUser(namespace, "moderation-offer-edit", {
+      role: "moderator",
+    });
+    const style = buildBeerStyle(namespace, "moderation-edit-style");
+    const brand = buildBeerBrand(namespace, "moderation-edit-brand");
+    const variant = buildBeerVariant(namespace, "moderation-edit-variant", {
+      brandId: brand.id,
+      styleId: style.id,
+    });
+    const location = buildLocation(namespace, "moderation-edit-location");
+    const offer = buildBeerOffer(namespace, "moderation-edit-offer", {
+      brand: brand.name,
+      variant: variant.name,
+      variantId: variant.id,
+      locationId: location.id,
+      priceCents: 450,
+    });
+
+    await db.beerStyle.create({ data: style });
+    await db.beerBrand.create({ data: brand });
+    await db.beerVariant.create({ data: variant });
+    await db.location.create({ data: location });
+    await db.beerOffer.create({ data: offer });
+    await startAuthenticatedSession(moderator.id);
+
+    const { PUT } = await import("@/app/api/v1/moderation/offers/[offerId]/route");
+    const response = await PUT(
+      new Request(`http://localhost/api/v1/moderation/offers/${offer.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ priceCents: 525 }),
+      }),
+      { params: Promise.resolve({ offerId: offer.id }) },
+    );
+
+    assert(response.status === 200, "Expected moderation offer edits to succeed.");
+
+    const updatedOffer = await db.beerOffer.findUnique({
+      where: { id: offer.id },
+      select: { priceCents: true },
+    });
+    const entry = await db.moderationAuditLog.findFirst({
+      where: { contentId: offer.id, action: "edit", contentType: "offer" },
+      orderBy: { createdAt: "desc" },
+    });
+
+    assert(
+      updatedOffer?.priceCents === 525,
+      "Expected moderation offer edits to persist the new price.",
+    );
+    if (!entry?.details) {
+      fail("Expected moderation offer edits to create an audit log entry with details.");
+    }
+
+    const details = JSON.parse(entry.details) as {
+      priceCents?: number;
+      previousPriceEur?: number;
+    };
+
+    assert(
+      details.priceCents === 525,
+      "Expected audit log details to include the updated priceCents.",
+    );
+    assert(
+      details.previousPriceEur === 4.5,
+      "Expected audit log details to include the previous price in EUR.",
+    );
+  });
+}
+
+async function testModerationOfferDeleteCreatesAuditLogEntry(): Promise<void> {
+  await runIntegrationTest("moderation-offer-delete-audit-log", async ({ namespace }) => {
+    const { user: moderator } = await seedAuthUser(namespace, "moderation-offer-delete", {
+      role: "moderator",
+    });
+    const style = buildBeerStyle(namespace, "moderation-delete-style");
+    const brand = buildBeerBrand(namespace, "moderation-delete-brand");
+    const variant = buildBeerVariant(namespace, "moderation-delete-variant", {
+      brandId: brand.id,
+      styleId: style.id,
+    });
+    const location = buildLocation(namespace, "moderation-delete-location");
+    const offer = buildBeerOffer(namespace, "moderation-delete-offer", {
+      brand: brand.name,
+      variant: variant.name,
+      variantId: variant.id,
+      locationId: location.id,
+      priceCents: 480,
+    });
+
+    await db.beerStyle.create({ data: style });
+    await db.beerBrand.create({ data: brand });
+    await db.beerVariant.create({ data: variant });
+    await db.location.create({ data: location });
+    await db.beerOffer.create({ data: offer });
+    await startAuthenticatedSession(moderator.id);
+
+    const { DELETE } = await import("@/app/api/v1/moderation/offers/[offerId]/route");
+    const response = await DELETE(
+      new Request(`http://localhost/api/v1/moderation/offers/${offer.id}`),
+      { params: Promise.resolve({ offerId: offer.id }) },
+    );
+
+    assert(response.status === 200, "Expected moderation offer deletes to succeed.");
+
+    const deletedOffer = await db.beerOffer.findUnique({ where: { id: offer.id } });
+    const entry = await db.moderationAuditLog.findFirst({
+      where: { contentId: offer.id, action: "delete", contentType: "offer" },
+      orderBy: { createdAt: "desc" },
+    });
+
+    assert(deletedOffer === null, "Expected moderation offer deletes to remove the offer.");
+    if (!entry?.details) {
+      fail("Expected moderation offer deletes to create an audit log entry with details.");
+    }
+
+    const details = JSON.parse(entry.details) as {
+      variant?: string;
+      location?: string;
+      priceEur?: number;
+    };
+
+    assert(
+      details.variant === variant.name,
+      "Expected audit log details to include the deleted variant name.",
+    );
+    assert(
+      details.location === location.name,
+      "Expected audit log details to include the deleted location name.",
+    );
+    assert(
+      details.priceEur === 4.8,
+      "Expected audit log details to include the deleted price in EUR.",
+    );
+  });
+}
+
+export const routeIntegrationChecks: IntegrationCheck[] = [
+  {
+    name: "admin brand create duplicate maps to BRAND_NAME_CONFLICT",
+    fn: testAdminBrandCreateDuplicateMapsConflict,
+  },
+  {
+    name: "admin brand edit duplicate maps to BRAND_NAME_CONFLICT",
+    fn: testAdminBrandEditDuplicateMapsConflict,
+  },
+  {
+    name: "admin brand delete in-use maps to BRAND_IN_USE",
+    fn: testAdminBrandDeleteInUseMapsConflict,
+  },
+  {
+    name: "admin variant create duplicate maps to VARIANT_NAME_CONFLICT",
+    fn: testAdminVariantCreateDuplicateMapsConflict,
+  },
+  {
+    name: "admin variant edit duplicate maps to VARIANT_NAME_CONFLICT",
+    fn: testAdminVariantEditDuplicateMapsConflict,
+  },
+  {
+    name: "admin variant delete in-use maps to VARIANT_IN_USE",
+    fn: testAdminVariantDeleteInUseMapsConflict,
+  },
+  {
+    name: "admin style delete in-use maps to STYLE_IN_USE",
+    fn: testAdminStyleDeleteInUseMapsConflict,
+  },
+  {
+    name: "admin offer create duplicate maps to OFFER_CONFLICT",
+    fn: testAdminOfferCreateDuplicateMapsConflict,
+  },
+  {
+    name: "moderation offer edit creates an audit log entry",
+    fn: testModerationOfferEditCreatesAuditLogEntry,
+  },
+  {
+    name: "moderation offer delete creates an audit log entry",
+    fn: testModerationOfferDeleteCreatesAuditLogEntry,
+  },
+];

--- a/integration-tests/routes.ts
+++ b/integration-tests/routes.ts
@@ -380,6 +380,176 @@ async function testModerationOfferEditCreatesAuditLogEntry(): Promise<void> {
   });
 }
 
+async function testModerationOfferApproveCreatesAuditLogEntry(): Promise<void> {
+  await runIntegrationTest("moderation-offer-approve-audit-log", async ({ namespace }) => {
+    const { user: moderator } = await seedAuthUser(namespace, "moderation-offer-approve", {
+      role: "moderator",
+    });
+    const style = buildBeerStyle(namespace, "moderation-approve-style");
+    const brand = buildBeerBrand(namespace, "moderation-approve-brand");
+    const variant = buildBeerVariant(namespace, "moderation-approve-variant", {
+      brandId: brand.id,
+      styleId: style.id,
+    });
+    const location = buildLocation(namespace, "moderation-approve-location");
+    const offer = buildBeerOffer(namespace, "moderation-approve-offer", {
+      brand: brand.name,
+      variant: variant.name,
+      variantId: variant.id,
+      locationId: location.id,
+      priceCents: 495,
+      status: "pending",
+    });
+
+    await db.beerStyle.create({ data: style });
+    await db.beerBrand.create({ data: brand });
+    await db.beerVariant.create({ data: variant });
+    await db.location.create({ data: location });
+    await db.beerOffer.create({ data: offer });
+    await startAuthenticatedSession(moderator.id);
+
+    const { PATCH } = await import("@/app/api/v1/moderation/offers/[offerId]/route");
+    const response = await PATCH(
+      new Request(`http://localhost/api/v1/moderation/offers/${offer.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "approved" }),
+      }),
+      { params: Promise.resolve({ offerId: offer.id }) },
+    );
+
+    assert(response.status === 200, "Expected moderation offer approvals to succeed.");
+
+    const approvedOffer = await db.beerOffer.findUnique({
+      where: { id: offer.id },
+      select: { status: true },
+    });
+    const priceHistory = await db.offerPriceHistory.findMany({
+      where: { beerOfferId: offer.id },
+    });
+    const entry = await db.moderationAuditLog.findFirst({
+      where: { contentId: offer.id, action: "approve", contentType: "offer" },
+      orderBy: { createdAt: "desc" },
+    });
+
+    assert(
+      approvedOffer?.status === "approved",
+      "Expected moderation offer approvals to persist the approved status.",
+    );
+    assert(
+      priceHistory.length === 1,
+      "Expected moderation offer approvals to create a price history entry.",
+    );
+    if (!entry?.details) {
+      fail("Expected moderation offer approvals to create an audit log entry with details.");
+    }
+
+    const details = JSON.parse(entry.details) as {
+      variant?: string;
+      location?: string;
+      priceEur?: number;
+    };
+
+    assert(
+      details.variant === variant.name,
+      "Expected audit log details to include the approved variant name.",
+    );
+    assert(
+      details.location === location.name,
+      "Expected audit log details to include the approved location name.",
+    );
+    assert(
+      details.priceEur === 4.95,
+      "Expected audit log details to include the approved price in EUR.",
+    );
+  });
+}
+
+async function testModerationOfferRejectCreatesAuditLogEntry(): Promise<void> {
+  await runIntegrationTest("moderation-offer-reject-audit-log", async ({ namespace }) => {
+    const { user: moderator } = await seedAuthUser(namespace, "moderation-offer-reject", {
+      role: "moderator",
+    });
+    const style = buildBeerStyle(namespace, "moderation-reject-style");
+    const brand = buildBeerBrand(namespace, "moderation-reject-brand");
+    const variant = buildBeerVariant(namespace, "moderation-reject-variant", {
+      brandId: brand.id,
+      styleId: style.id,
+    });
+    const location = buildLocation(namespace, "moderation-reject-location");
+    const offer = buildBeerOffer(namespace, "moderation-reject-offer", {
+      brand: brand.name,
+      variant: variant.name,
+      variantId: variant.id,
+      locationId: location.id,
+      priceCents: 510,
+      status: "pending",
+    });
+
+    await db.beerStyle.create({ data: style });
+    await db.beerBrand.create({ data: brand });
+    await db.beerVariant.create({ data: variant });
+    await db.location.create({ data: location });
+    await db.beerOffer.create({ data: offer });
+    await startAuthenticatedSession(moderator.id);
+
+    const { PATCH } = await import("@/app/api/v1/moderation/offers/[offerId]/route");
+    const response = await PATCH(
+      new Request(`http://localhost/api/v1/moderation/offers/${offer.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "rejected" }),
+      }),
+      { params: Promise.resolve({ offerId: offer.id }) },
+    );
+
+    assert(response.status === 200, "Expected moderation offer rejections to succeed.");
+
+    const rejectedOffer = await db.beerOffer.findUnique({
+      where: { id: offer.id },
+      select: { status: true },
+    });
+    const priceHistory = await db.offerPriceHistory.findMany({
+      where: { beerOfferId: offer.id },
+    });
+    const entry = await db.moderationAuditLog.findFirst({
+      where: { contentId: offer.id, action: "reject", contentType: "offer" },
+      orderBy: { createdAt: "desc" },
+    });
+
+    assert(
+      rejectedOffer?.status === "rejected",
+      "Expected moderation offer rejections to persist the rejected status.",
+    );
+    assert(
+      priceHistory.length === 0,
+      "Expected moderation offer rejections not to create a price history entry.",
+    );
+    if (!entry?.details) {
+      fail("Expected moderation offer rejections to create an audit log entry with details.");
+    }
+
+    const details = JSON.parse(entry.details) as {
+      brand?: string;
+      serving?: string;
+      priceEur?: number;
+    };
+
+    assert(
+      details.brand === brand.name,
+      "Expected audit log details to include the rejected brand name.",
+    );
+    assert(
+      details.serving === "tap",
+      "Expected audit log details to include the rejected serving type.",
+    );
+    assert(
+      details.priceEur === 5.1,
+      "Expected audit log details to include the rejected price in EUR.",
+    );
+  });
+}
+
 async function testModerationOfferDeleteCreatesAuditLogEntry(): Promise<void> {
   await runIntegrationTest("moderation-offer-delete-audit-log", async ({ namespace }) => {
     const { user: moderator } = await seedAuthUser(namespace, "moderation-offer-delete", {
@@ -479,6 +649,14 @@ export const routeIntegrationChecks: IntegrationCheck[] = [
   {
     name: "admin offer create duplicate maps to OFFER_CONFLICT",
     fn: testAdminOfferCreateDuplicateMapsConflict,
+  },
+  {
+    name: "moderation offer approve creates an audit log entry",
+    fn: testModerationOfferApproveCreatesAuditLogEntry,
+  },
+  {
+    name: "moderation offer reject creates an audit log entry",
+    fn: testModerationOfferRejectCreatesAuditLogEntry,
   },
   {
     name: "moderation offer edit creates an audit log entry",

--- a/integration-tests/run.ts
+++ b/integration-tests/run.ts
@@ -24,7 +24,12 @@ import {
   buildLocation,
   buildUser,
 } from "../test/factories";
-import { assert, runIntegrationTest } from "./helpers";
+import {
+  assert,
+  closeIntegrationTestResources,
+  runIntegrationTest,
+  seedCatalogFixture,
+} from "./helpers";
 
 async function testGetLocationByIdApproval(): Promise<void> {
   await runIntegrationTest("get-location-by-id-approval", async ({ namespace }) => {
@@ -48,19 +53,16 @@ async function testGetLocationByIdApproval(): Promise<void> {
 
 async function testGetBeerOffersFiltersApprovedOnly(): Promise<void> {
   await runIntegrationTest("get-beer-offers-approved-only", async ({ namespace }) => {
-    const style = buildBeerStyle(namespace, "style");
-    const brand = buildBeerBrand(namespace, "brand");
-    const variant = buildBeerVariant(namespace, "variant", {
-      brandId: brand.id,
-      styleId: style.id,
-    });
-    const location = buildLocation(namespace, "offers place");
-    const approvedOffer = buildBeerOffer(namespace, "approved", {
-      brand: "Approved Brand",
-      variant: "Approved Variant",
-      variantId: variant.id,
-      locationId: location.id,
-      priceCents: 333,
+    const {
+      variant,
+      location,
+      offer: approvedOffer,
+    } = await seedCatalogFixture(namespace, "offers", {
+      offer: {
+        brand: "Approved Brand",
+        variant: "Approved Variant",
+        priceCents: 333,
+      },
     });
     const pendingOffer = buildBeerOffer(namespace, "pending", {
       brand: "Pending Brand",
@@ -72,11 +74,10 @@ async function testGetBeerOffersFiltersApprovedOnly(): Promise<void> {
       status: "pending",
     });
 
-    await db.beerStyle.create({ data: style });
-    await db.beerBrand.create({ data: brand });
-    await db.beerVariant.create({ data: variant });
-    await db.location.create({ data: location });
-    await db.beerOffer.create({ data: approvedOffer });
+    if (!approvedOffer) {
+      throw new Error("Expected approved offer fixture to be created.");
+    }
+
     await db.beerOffer.create({ data: pendingOffer });
 
     const offers = await getBeerOffers();
@@ -236,29 +237,22 @@ async function testCreateOfferOrPriceUpdateProposalFlow(): Promise<void> {
 
 async function testCreateOfferOrPriceUpdateProposalSamePriceFlow(): Promise<void> {
   await runIntegrationTest("offer-or-price-update-same-price", async ({ namespace }) => {
-    const style = buildBeerStyle(namespace, "same price style");
-    const brand = buildBeerBrand(namespace, "same price brand");
-    const variant = buildBeerVariant(namespace, "same price variant", {
-      brandId: brand.id,
-      styleId: style.id,
-    });
-    const location = buildLocation(namespace, "same price location");
-    const existingOffer = buildBeerOffer(namespace, "same price offer", {
-      brand: brand.name,
-      variant: variant.name,
-      variantId: variant.id,
-      locationId: location.id,
-      sizeMl: 330,
-      serving: "can",
-      priceCents: 299,
-      status: "approved",
+    const {
+      variant,
+      location,
+      offer: existingOffer,
+    } = await seedCatalogFixture(namespace, "same price", {
+      offer: {
+        sizeMl: 330,
+        serving: "can",
+        priceCents: 299,
+        status: "approved",
+      },
     });
 
-    await db.beerStyle.create({ data: style });
-    await db.beerBrand.create({ data: brand });
-    await db.beerVariant.create({ data: variant });
-    await db.location.create({ data: location });
-    await db.beerOffer.create({ data: existingOffer });
+    if (!existingOffer) {
+      throw new Error("Expected same-price offer fixture to be created.");
+    }
 
     const result = await createOfferOrPriceUpdateProposal({
       variantId: variant.id,
@@ -297,29 +291,22 @@ async function testCreateOfferOrPriceUpdateProposalSamePriceFlow(): Promise<void
 
 async function testCreateOfferOrPriceUpdateProposalPendingOfferFlow(): Promise<void> {
   await runIntegrationTest("offer-or-price-update-existing-pending", async ({ namespace }) => {
-    const style = buildBeerStyle(namespace, "pending offer style");
-    const brand = buildBeerBrand(namespace, "pending offer brand");
-    const variant = buildBeerVariant(namespace, "pending offer variant", {
-      brandId: brand.id,
-      styleId: style.id,
-    });
-    const location = buildLocation(namespace, "pending offer location");
-    const existingOffer = buildBeerOffer(namespace, "pending offer", {
-      brand: brand.name,
-      variant: variant.name,
-      variantId: variant.id,
-      locationId: location.id,
-      sizeMl: 500,
-      serving: "tap",
-      priceCents: 420,
-      status: "pending",
+    const {
+      variant,
+      location,
+      offer: existingOffer,
+    } = await seedCatalogFixture(namespace, "pending offer", {
+      offer: {
+        sizeMl: 500,
+        serving: "tap",
+        priceCents: 420,
+        status: "pending",
+      },
     });
 
-    await db.beerStyle.create({ data: style });
-    await db.beerBrand.create({ data: brand });
-    await db.beerVariant.create({ data: variant });
-    await db.location.create({ data: location });
-    await db.beerOffer.create({ data: existingOffer });
+    if (!existingOffer) {
+      throw new Error("Expected pending-offer fixture to be created.");
+    }
 
     const result = await createOfferOrPriceUpdateProposal({
       variantId: variant.id,
@@ -827,10 +814,12 @@ async function run(): Promise<void> {
 
 run()
   .then(async () => {
+    await closeIntegrationTestResources();
     await db.$disconnect();
   })
   .catch(async (error) => {
     console.error("Integration checks failed:", error);
+    await closeIntegrationTestResources();
     await db.$disconnect();
     process.exit(1);
   });

--- a/integration-tests/run.ts
+++ b/integration-tests/run.ts
@@ -127,6 +127,45 @@ async function testCreateOfferOrPriceUpdateProposalFlow(): Promise<void> {
       return;
     }
 
+    const createdOffer = await db.beerOffer.findUnique({
+      where: { id: first.offer.id },
+      select: {
+        id: true,
+        status: true,
+        priceCents: true,
+        locationId: true,
+        variantId: true,
+        sizeMl: true,
+        serving: true,
+      },
+    });
+    const firstProposalCount = await db.priceUpdateProposal.count({
+      where: { beerOfferId: first.offer.id },
+    });
+
+    assert(createdOffer?.status === "pending", "Expected first submit to persist a pending offer.");
+    assert(
+      createdOffer?.priceCents === 450,
+      "Expected first submit to persist the submitted offer price.",
+    );
+    assert(
+      createdOffer?.locationId === location.id,
+      "Expected first submit to persist the target location.",
+    );
+    assert(
+      createdOffer?.variantId === variant.id,
+      "Expected first submit to persist the target variant.",
+    );
+    assert(createdOffer?.sizeMl === 400, "Expected first submit to persist the submitted size.");
+    assert(
+      createdOffer?.serving === "bottle",
+      "Expected first submit to persist the submitted serving.",
+    );
+    assert(
+      firstProposalCount === 0,
+      "Expected first submit not to create a price update proposal.",
+    );
+
     await db.beerOffer.update({
       where: { id: first.offer.id },
       data: { status: "approved" },
@@ -150,6 +189,190 @@ async function testCreateOfferOrPriceUpdateProposalFlow(): Promise<void> {
     assert(
       second.proposal.proposedPriceEur === 4.7,
       "Expected proposal price to be converted to EUR.",
+    );
+
+    const persistedOffer = await db.beerOffer.findUnique({
+      where: { id: first.offer.id },
+      select: { status: true, priceCents: true },
+    });
+    const persistedProposal = await db.priceUpdateProposal.findUnique({
+      where: { id: second.proposal.id },
+      select: {
+        beerOfferId: true,
+        proposedPriceCents: true,
+        status: true,
+      },
+    });
+    const proposalCount = await db.priceUpdateProposal.count({
+      where: { beerOfferId: first.offer.id },
+    });
+
+    assert(
+      persistedOffer?.status === "approved",
+      "Expected the existing offer to remain approved after creating a price update proposal.",
+    );
+    assert(
+      persistedOffer?.priceCents === 450,
+      "Expected the existing offer price to remain unchanged until proposal approval.",
+    );
+    assert(
+      persistedProposal?.beerOfferId === first.offer.id,
+      "Expected the persisted price update proposal to reference the existing offer.",
+    );
+    assert(
+      persistedProposal?.proposedPriceCents === 470,
+      "Expected the persisted price update proposal to keep the submitted price.",
+    );
+    assert(
+      persistedProposal?.status === "pending",
+      "Expected the persisted price update proposal to remain pending.",
+    );
+    assert(
+      proposalCount === 1,
+      "Expected exactly one price update proposal for the existing offer.",
+    );
+  });
+}
+
+async function testCreateOfferOrPriceUpdateProposalSamePriceFlow(): Promise<void> {
+  await runIntegrationTest("offer-or-price-update-same-price", async ({ namespace }) => {
+    const style = buildBeerStyle(namespace, "same price style");
+    const brand = buildBeerBrand(namespace, "same price brand");
+    const variant = buildBeerVariant(namespace, "same price variant", {
+      brandId: brand.id,
+      styleId: style.id,
+    });
+    const location = buildLocation(namespace, "same price location");
+    const existingOffer = buildBeerOffer(namespace, "same price offer", {
+      brand: brand.name,
+      variant: variant.name,
+      variantId: variant.id,
+      locationId: location.id,
+      sizeMl: 330,
+      serving: "can",
+      priceCents: 299,
+      status: "approved",
+    });
+
+    await db.beerStyle.create({ data: style });
+    await db.beerBrand.create({ data: brand });
+    await db.beerVariant.create({ data: variant });
+    await db.location.create({ data: location });
+    await db.beerOffer.create({ data: existingOffer });
+
+    const result = await createOfferOrPriceUpdateProposal({
+      variantId: variant.id,
+      sizeMl: 330,
+      serving: "can",
+      priceCents: 299,
+      locationId: location.id,
+      status: "pending",
+    });
+
+    assert(result.outcome === "same_price", "Expected identical prices to return same_price.");
+    if (result.outcome !== "same_price") {
+      return;
+    }
+
+    const offerCount = await db.beerOffer.count({
+      where: {
+        locationId: location.id,
+        variantId: variant.id,
+        sizeMl: 330,
+        serving: "can",
+      },
+    });
+    const proposalCount = await db.priceUpdateProposal.count({
+      where: { beerOfferId: existingOffer.id },
+    });
+
+    assert(
+      result.offer.id === existingOffer.id,
+      "Expected same_price to reference the existing offer.",
+    );
+    assert(offerCount === 1, "Expected same_price not to create a duplicate offer row.");
+    assert(proposalCount === 0, "Expected same_price not to create a price update proposal.");
+  });
+}
+
+async function testCreateOfferOrPriceUpdateProposalPendingOfferFlow(): Promise<void> {
+  await runIntegrationTest("offer-or-price-update-existing-pending", async ({ namespace }) => {
+    const style = buildBeerStyle(namespace, "pending offer style");
+    const brand = buildBeerBrand(namespace, "pending offer brand");
+    const variant = buildBeerVariant(namespace, "pending offer variant", {
+      brandId: brand.id,
+      styleId: style.id,
+    });
+    const location = buildLocation(namespace, "pending offer location");
+    const existingOffer = buildBeerOffer(namespace, "pending offer", {
+      brand: brand.name,
+      variant: variant.name,
+      variantId: variant.id,
+      locationId: location.id,
+      sizeMl: 500,
+      serving: "tap",
+      priceCents: 420,
+      status: "pending",
+    });
+
+    await db.beerStyle.create({ data: style });
+    await db.beerBrand.create({ data: brand });
+    await db.beerVariant.create({ data: variant });
+    await db.location.create({ data: location });
+    await db.beerOffer.create({ data: existingOffer });
+
+    const result = await createOfferOrPriceUpdateProposal({
+      variantId: variant.id,
+      sizeMl: 500,
+      serving: "tap",
+      priceCents: 450,
+      locationId: location.id,
+      status: "pending",
+    });
+
+    assert(
+      result.outcome === "existing_offer_not_approved",
+      "Expected a pending existing offer to block branching into a price update proposal.",
+    );
+    if (result.outcome !== "existing_offer_not_approved") {
+      return;
+    }
+
+    const offerCount = await db.beerOffer.count({
+      where: {
+        locationId: location.id,
+        variantId: variant.id,
+        sizeMl: 500,
+        serving: "tap",
+      },
+    });
+    const proposalCount = await db.priceUpdateProposal.count({
+      where: { beerOfferId: existingOffer.id },
+    });
+    const persistedOffer = await db.beerOffer.findUnique({
+      where: { id: existingOffer.id },
+      select: { status: true, priceCents: true },
+    });
+
+    assert(
+      result.offer.id === existingOffer.id,
+      "Expected existing_offer_not_approved to reference the pending existing offer.",
+    );
+    assert(
+      offerCount === 1,
+      "Expected existing_offer_not_approved not to create a duplicate offer row.",
+    );
+    assert(
+      proposalCount === 0,
+      "Expected existing_offer_not_approved not to create a price update proposal.",
+    );
+    assert(
+      persistedOffer?.status === "pending",
+      "Expected the existing pending offer to remain pending after the blocked submission.",
+    );
+    assert(
+      persistedOffer?.priceCents === 420,
+      "Expected the existing pending offer price to remain unchanged after the blocked submission.",
     );
   });
 }
@@ -554,6 +777,14 @@ async function run(): Promise<void> {
     { name: "getLocationById only exposes approved", fn: testGetLocationByIdApproval },
     { name: "getBeerOffers filters approved offers", fn: testGetBeerOffersFiltersApprovedOnly },
     { name: "offer submission to price update flow", fn: testCreateOfferOrPriceUpdateProposalFlow },
+    {
+      name: "offer submission same-price branch preserves persistence",
+      fn: testCreateOfferOrPriceUpdateProposalSamePriceFlow,
+    },
+    {
+      name: "offer submission pending-offer branch preserves persistence",
+      fn: testCreateOfferOrPriceUpdateProposalPendingOfferFlow,
+    },
     {
       name: "createBeerOffer snapshots variant names",
       fn: testCreateBeerOfferSnapshotsVariantNames,

--- a/integration-tests/run.ts
+++ b/integration-tests/run.ts
@@ -15,6 +15,7 @@ import {
   moderatePriceUpdateProposal,
 } from "@/lib/query";
 import { authIntegrationChecks } from "./auth";
+import { routeIntegrationChecks } from "./routes";
 import {
   buildBeerBrand,
   buildBeerOffer,
@@ -549,6 +550,7 @@ async function testDuplicateStyleNameBlocksCreation(): Promise<void> {
 async function run(): Promise<void> {
   const checks: Array<{ name: string; fn: () => Promise<void> }> = [
     ...authIntegrationChecks,
+    ...routeIntegrationChecks,
     { name: "getLocationById only exposes approved", fn: testGetLocationByIdApproval },
     { name: "getBeerOffers filters approved offers", fn: testGetBeerOffersFiltersApprovedOnly },
     { name: "offer submission to price update flow", fn: testCreateOfferOrPriceUpdateProposalFlow },

--- a/integration-tests/run.ts
+++ b/integration-tests/run.ts
@@ -14,6 +14,7 @@ import {
   moderateLocationSubmission,
   moderatePriceUpdateProposal,
 } from "@/lib/query";
+import { authIntegrationChecks } from "./auth";
 import {
   buildBeerBrand,
   buildBeerOffer,
@@ -547,6 +548,7 @@ async function testDuplicateStyleNameBlocksCreation(): Promise<void> {
 
 async function run(): Promise<void> {
   const checks: Array<{ name: string; fn: () => Promise<void> }> = [
+    ...authIntegrationChecks,
     { name: "getLocationById only exposes approved", fn: testGetLocationByIdApproval },
     { name: "getBeerOffers filters approved offers", fn: testGetBeerOffersFiltersApprovedOnly },
     { name: "offer submission to price update flow", fn: testCreateOfferOrPriceUpdateProposalFlow },

--- a/integration-tests/run.ts
+++ b/integration-tests/run.ts
@@ -3,7 +3,6 @@ import { db } from "@/lib/db";
 import {
   createAdminStyle,
   createBeerOffer,
-  createLocation,
   createOfferOrPriceUpdateProposal,
   getDistinctApprovedOfferSizes,
   getBeerOffers,
@@ -16,19 +15,13 @@ import {
 } from "@/lib/query";
 import { authIntegrationChecks } from "./auth";
 import { routeIntegrationChecks } from "./routes";
-import {
-  buildBeerBrand,
-  buildBeerOffer,
-  buildBeerStyle,
-  buildBeerVariant,
-  buildLocation,
-  buildUser,
-} from "../test/factories";
+import { buildBeerOffer, buildLocation, buildUser } from "../test";
 import {
   assert,
   closeIntegrationTestResources,
   runIntegrationTest,
   seedCatalogFixture,
+  seedCatalogOfferFixture,
 } from "./helpers";
 
 async function testGetLocationByIdApproval(): Promise<void> {
@@ -95,24 +88,7 @@ async function testGetBeerOffersFiltersApprovedOnly(): Promise<void> {
 
 async function testCreateOfferOrPriceUpdateProposalFlow(): Promise<void> {
   await runIntegrationTest("offer-or-price-update-flow", async ({ namespace }) => {
-    const style = buildBeerStyle(namespace, "flow style");
-    const brand = buildBeerBrand(namespace, "flow brand");
-    const variant = buildBeerVariant(namespace, "flow variant", {
-      brandId: brand.id,
-      styleId: style.id,
-    });
-
-    await db.beerStyle.create({ data: style });
-    await db.beerBrand.create({ data: brand });
-    await db.beerVariant.create({ data: variant });
-
-    const location = await createLocation({
-      name: namespace.name("Flow Place"),
-      locationType: "pub",
-      district: "Mitte",
-      address: "Flow Street 1",
-      status: "approved",
-    });
+    const { variant, location } = await seedCatalogFixture(namespace, "flow", { offer: false });
 
     const first = await createOfferOrPriceUpdateProposal({
       variantId: variant.id,
@@ -366,23 +342,13 @@ async function testCreateOfferOrPriceUpdateProposalPendingOfferFlow(): Promise<v
 
 async function testCreateBeerOfferSnapshotsVariantNames(): Promise<void> {
   await runIntegrationTest("create-beer-offer-snapshots", async ({ namespace }) => {
-    const style = buildBeerStyle(namespace, "snapshot style");
-    const brand = buildBeerBrand(namespace, "snapshot brand");
-    const variantSeed = buildBeerVariant(namespace, "snapshot variant", {
-      brandId: brand.id,
-      styleId: style.id,
-    });
-
-    await db.beerStyle.create({ data: style });
-    await db.beerBrand.create({ data: brand });
-    await db.beerVariant.create({ data: variantSeed });
-
-    const location = await createLocation({
-      name: namespace.name("Snapshot Place"),
-      locationType: "supermarket",
-      district: "West",
-      address: "Snapshot 42",
-      status: "approved",
+    const { variant: variantSeed, location } = await seedCatalogFixture(namespace, "snapshot", {
+      offer: false,
+      location: {
+        locationType: "supermarket",
+        district: "West",
+        address: "Snapshot 42",
+      },
     });
 
     const created = await createBeerOffer({
@@ -408,34 +374,21 @@ async function testCreateBeerOfferSnapshotsVariantNames(): Promise<void> {
 
 async function testGetOfferPriceHistoryBatchGroupsByOffer(): Promise<void> {
   await runIntegrationTest("offer-price-history-batch", async ({ namespace }) => {
-    const style = buildBeerStyle(namespace, "batch style");
-    const brand = buildBeerBrand(namespace, "batch brand");
-    const variant = buildBeerVariant(namespace, "batch variant", {
-      brandId: brand.id,
-      styleId: style.id,
-    });
-    const location = buildLocation(namespace, "batch location");
-    const offerOne = buildBeerOffer(namespace, "one", {
-      brand: brand.name,
-      variant: variant.name,
-      variantId: variant.id,
-      locationId: location.id,
-      priceCents: 420,
+    const {
+      variant,
+      location,
+      offer: offerOne,
+    } = await seedCatalogOfferFixture(namespace, "batch one", {
+      offer: { priceCents: 420 },
     });
     const offerTwo = buildBeerOffer(namespace, "two", {
-      brand: brand.name,
-      variant: variant.name,
+      brand: offerOne.brand,
+      variant: offerOne.variant,
       variantId: variant.id,
       locationId: location.id,
       priceCents: 510,
       sizeMl: 330,
     });
-
-    await db.beerStyle.create({ data: style });
-    await db.beerBrand.create({ data: brand });
-    await db.beerVariant.create({ data: variant });
-    await db.location.create({ data: location });
-    await db.beerOffer.create({ data: offerOne });
     await db.beerOffer.create({ data: offerTwo });
 
     await db.offerPriceHistory.create({
@@ -484,37 +437,23 @@ async function testGetOfferPriceHistoryBatchGroupsByOffer(): Promise<void> {
 
 async function testGetDistinctApprovedOfferSizesReturnsSortedUniqueValues(): Promise<void> {
   await runIntegrationTest("distinct-approved-offer-sizes", async ({ namespace }) => {
-    const style = buildBeerStyle(namespace, "size style");
-    const brand = buildBeerBrand(namespace, "size brand");
-    const variant = buildBeerVariant(namespace, "size variant", {
-      brandId: brand.id,
-      styleId: style.id,
+    const {
+      variant,
+      location: approvedLocation,
+      offer,
+    } = await seedCatalogOfferFixture(namespace, "size approved", {
+      offer: { sizeMl: 123 },
     });
-    const approvedLocation = buildLocation(namespace, "approved location");
     const pendingLocation = buildLocation(namespace, "pending location", {
       id: namespace.id("location-pending"),
       status: "pending",
     });
 
-    await db.beerStyle.create({ data: style });
-    await db.beerBrand.create({ data: brand });
-    await db.beerVariant.create({ data: variant });
-    await db.location.create({ data: approvedLocation });
     await db.location.create({ data: pendingLocation });
-
-    await db.beerOffer.create({
-      data: buildBeerOffer(namespace, "size-500-a", {
-        brand: brand.name,
-        variant: variant.name,
-        variantId: variant.id,
-        locationId: approvedLocation.id,
-        sizeMl: 123,
-      }),
-    });
     await db.beerOffer.create({
       data: buildBeerOffer(namespace, "size-500-b", {
-        brand: brand.name,
-        variant: variant.name,
+        brand: offer.brand,
+        variant: offer.variant,
         variantId: variant.id,
         locationId: approvedLocation.id,
         sizeMl: 123,
@@ -523,8 +462,8 @@ async function testGetDistinctApprovedOfferSizesReturnsSortedUniqueValues(): Pro
     });
     await db.beerOffer.create({
       data: buildBeerOffer(namespace, "size-330", {
-        brand: brand.name,
-        variant: variant.name,
+        brand: offer.brand,
+        variant: offer.variant,
         variantId: variant.id,
         locationId: approvedLocation.id,
         sizeMl: 987,
@@ -532,8 +471,8 @@ async function testGetDistinctApprovedOfferSizesReturnsSortedUniqueValues(): Pro
     });
     await db.beerOffer.create({
       data: buildBeerOffer(namespace, "size-hidden", {
-        brand: brand.name,
-        variant: variant.name,
+        brand: offer.brand,
+        variant: offer.variant,
         variantId: variant.id,
         locationId: pendingLocation.id,
         sizeMl: 777,
@@ -585,27 +524,9 @@ async function testLogModerationActionPersistsEntry(): Promise<void> {
 
 async function testModerateBeerOfferApprovalCreatesHistoryEntry(): Promise<void> {
   await runIntegrationTest("moderate-offer-approval-history", async ({ namespace }) => {
-    const style = buildBeerStyle(namespace, "mod style");
-    const brand = buildBeerBrand(namespace, "mod brand");
-    const variant = buildBeerVariant(namespace, "mod variant", {
-      brandId: brand.id,
-      styleId: style.id,
+    const { offer } = await seedCatalogOfferFixture(namespace, "moderate offer", {
+      offer: { priceCents: 390, status: "pending" },
     });
-    const location = buildLocation(namespace, "mod location");
-    const offer = buildBeerOffer(namespace, "mod offer", {
-      brand: brand.name,
-      variant: variant.name,
-      variantId: variant.id,
-      locationId: location.id,
-      priceCents: 390,
-      status: "pending",
-    });
-
-    await db.beerStyle.create({ data: style });
-    await db.beerBrand.create({ data: brand });
-    await db.beerVariant.create({ data: variant });
-    await db.location.create({ data: location });
-    await db.beerOffer.create({ data: offer });
 
     const result = await moderateBeerOfferSubmission(offer.id, "approved");
 
@@ -625,26 +546,9 @@ async function testModerateBeerOfferApprovalCreatesHistoryEntry(): Promise<void>
 
 async function testModeratePriceUpdateApprovalUpdatesOfferAndCreatesHistory(): Promise<void> {
   await runIntegrationTest("moderate-price-update-approval", async ({ namespace }) => {
-    const style = buildBeerStyle(namespace, "pup style");
-    const brand = buildBeerBrand(namespace, "pup brand");
-    const variant = buildBeerVariant(namespace, "pup variant", {
-      brandId: brand.id,
-      styleId: style.id,
+    const { offer } = await seedCatalogOfferFixture(namespace, "price update approval", {
+      offer: { priceCents: 450 },
     });
-    const location = buildLocation(namespace, "pup location");
-    const offer = buildBeerOffer(namespace, "pup offer", {
-      brand: brand.name,
-      variant: variant.name,
-      variantId: variant.id,
-      locationId: location.id,
-      priceCents: 450,
-    });
-
-    await db.beerStyle.create({ data: style });
-    await db.beerBrand.create({ data: brand });
-    await db.beerVariant.create({ data: variant });
-    await db.location.create({ data: location });
-    await db.beerOffer.create({ data: offer });
 
     // Seed an initial price history entry (simulating prior approval)
     await db.offerPriceHistory.create({
@@ -690,34 +594,22 @@ async function testModeratePriceUpdateApprovalUpdatesOfferAndCreatesHistory(): P
 
 async function testRejectedLocationCascadesPendingOffers(): Promise<void> {
   await runIntegrationTest("rejected-location-cascades-offers", async ({ namespace }) => {
-    const style = buildBeerStyle(namespace, "cas style");
-    const brand = buildBeerBrand(namespace, "cas brand");
-    const variant = buildBeerVariant(namespace, "cas variant", {
-      brandId: brand.id,
-      styleId: style.id,
-    });
-    const location = buildLocation(namespace, "cas location", { status: "pending" });
-    const pendingOffer = buildBeerOffer(namespace, "cas pending offer", {
-      brand: brand.name,
-      variant: variant.name,
-      variantId: variant.id,
-      locationId: location.id,
-      status: "pending",
+    const {
+      variant,
+      location,
+      offer: pendingOffer,
+    } = await seedCatalogOfferFixture(namespace, "cascade location", {
+      location: { status: "pending" },
+      offer: { status: "pending" },
     });
     const approvedOffer = buildBeerOffer(namespace, "cas approved offer", {
-      brand: brand.name,
-      variant: variant.name,
+      brand: pendingOffer.brand,
+      variant: pendingOffer.variant,
       variantId: variant.id,
       locationId: location.id,
       serving: "bottle",
       status: "approved",
     });
-
-    await db.beerStyle.create({ data: style });
-    await db.beerBrand.create({ data: brand });
-    await db.beerVariant.create({ data: variant });
-    await db.location.create({ data: location });
-    await db.beerOffer.create({ data: pendingOffer });
     await db.beerOffer.create({ data: approvedOffer });
 
     const result = await moderateLocationSubmission(location.id, "rejected");

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:integration": "tsx integration-tests/run.ts",
+    "test:integration": "node --import ./integration-tests/register-server-only.mjs --import tsx integration-tests/run.ts",
     "test:e2e": "playwright test",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",

--- a/src/app/admin/users/users-management.tsx
+++ b/src/app/admin/users/users-management.tsx
@@ -27,6 +27,8 @@ type UsersManagementProps = {
 function UserItem({
   user,
   currentAdminId,
+  expanded,
+  onToggle,
   selectedRole,
   onRoleChange,
   onSaveRole,
@@ -44,6 +46,8 @@ function UserItem({
 }: {
   user: UserForAdmin;
   currentAdminId: string;
+  expanded: boolean;
+  onToggle: () => void;
   selectedRole: UserRole;
   onRoleChange: (role: UserRole) => void;
   onSaveRole: () => void;
@@ -59,7 +63,6 @@ function UserItem({
   unbanning: boolean;
   deleting: boolean;
 }) {
-  const [expanded, setExpanded] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const roleChanged = selectedRole !== user.role;
   const isSelf = user.id === currentAdminId;
@@ -81,7 +84,7 @@ function UserItem({
         ) : undefined
       }
       expanded={expanded}
-      onToggle={() => setExpanded((prev) => !prev)}
+      onToggle={onToggle}
     >
       <div className={styles.meta}>
         <p>
@@ -195,6 +198,8 @@ function UserGroup({
   headingId,
   users,
   currentAdminId,
+  expandedUsers,
+  onToggleExpand,
   selectedRoles,
   onRoleChange,
   onSaveRole,
@@ -214,6 +219,8 @@ function UserGroup({
   headingId: string;
   users: UserForAdmin[];
   currentAdminId: string;
+  expandedUsers: Record<string, boolean>;
+  onToggleExpand: (userId: string) => void;
   selectedRoles: Record<string, UserRole>;
   onRoleChange: (userId: string, role: UserRole) => void;
   onSaveRole: (userId: string) => void;
@@ -242,6 +249,8 @@ function UserGroup({
             key={user.id}
             user={user}
             currentAdminId={currentAdminId}
+            expanded={expandedUsers[user.id] ?? false}
+            onToggle={() => onToggleExpand(user.id)}
             selectedRole={selectedRoles[user.id] ?? user.role}
             onRoleChange={(role) => onRoleChange(user.id, role)}
             onSaveRole={() => onSaveRole(user.id)}
@@ -268,6 +277,7 @@ export function UsersManagement({ currentAdminId, users }: UsersManagementProps)
   const [selectedRoles, setSelectedRoles] = useState<Record<string, UserRole>>(
     Object.fromEntries(users.map((user) => [user.id, user.role])),
   );
+  const [expandedUsers, setExpandedUsers] = useState<Record<string, boolean>>({});
   const [pendingUserId, setPendingUserId] = useState<string | null>(null);
   const [verifyingUserId, setVerifyingUserId] = useState<string | null>(null);
   const [resendingUserId, setResendingUserId] = useState<string | null>(null);
@@ -401,6 +411,9 @@ export function UsersManagement({ currentAdminId, users }: UsersManagementProps)
 
   const groupProps = {
     currentAdminId,
+    expandedUsers,
+    onToggleExpand: (userId: string) =>
+      setExpandedUsers((current) => ({ ...current, [userId]: !current[userId] })),
     selectedRoles,
     onRoleChange: (userId: string, role: UserRole) =>
       setSelectedRoles((current) => ({ ...current, [userId]: role })),

--- a/src/app/api/v1/admin/brands/[brandId]/route.ts
+++ b/src/app/api/v1/admin/brands/[brandId]/route.ts
@@ -1,4 +1,5 @@
 import { jsonError, jsonOk } from "@/lib/http";
+import { isPrismaErrorCode } from "@/lib/prisma-errors";
 import { deleteModerationBrand, editAdminBrand, logModerationAction } from "@/lib/query";
 import { parseJsonBody, withApiAdmin, withMetrics } from "@/lib/route-handlers";
 import { editAdminBrandBodySchema } from "@/lib/validation";
@@ -15,7 +16,17 @@ async function putHandler(
     }
 
     const { brandId } = await context.params;
-    const result = await editAdminBrand(brandId, parsed.data.name);
+    let result;
+
+    try {
+      result = await editAdminBrand(brandId, parsed.data.name);
+    } catch (error) {
+      if (isPrismaErrorCode(error, "P2002")) {
+        return jsonError(409, "BRAND_NAME_CONFLICT", "A beer brand with that name already exists.");
+      }
+
+      throw error;
+    }
 
     if (!result) {
       return jsonError(404, "BRAND_NOT_FOUND", `No brand found for id '${brandId}'.`);
@@ -40,7 +51,21 @@ async function deleteHandler(
 ): Promise<Response> {
   return withApiAdmin(async (admin) => {
     const { brandId } = await context.params;
-    const result = await deleteModerationBrand(brandId);
+    let result;
+
+    try {
+      result = await deleteModerationBrand(brandId);
+    } catch (error) {
+      if (isPrismaErrorCode(error, "P2003")) {
+        return jsonError(
+          409,
+          "BRAND_IN_USE",
+          "This beer brand is still in use and cannot be deleted.",
+        );
+      }
+
+      throw error;
+    }
 
     if (!result.deleted) {
       return jsonError(404, "BRAND_NOT_FOUND", `No brand found for id '${brandId}'.`);

--- a/src/app/api/v1/admin/variants/[variantId]/route.ts
+++ b/src/app/api/v1/admin/variants/[variantId]/route.ts
@@ -1,4 +1,5 @@
 import { jsonError, jsonOk } from "@/lib/http";
+import { isPrismaErrorCode } from "@/lib/prisma-errors";
 import { deleteModerationVariant, editAdminVariant, logModerationAction } from "@/lib/query";
 import { parseJsonBody, withApiAdmin, withMetrics } from "@/lib/route-handlers";
 import { editAdminVariantBodySchema } from "@/lib/validation";
@@ -15,7 +16,25 @@ async function putHandler(
     }
 
     const { variantId } = await context.params;
-    const result = await editAdminVariant(variantId, parsed.data);
+    let result;
+
+    try {
+      result = await editAdminVariant(variantId, parsed.data);
+    } catch (error) {
+      if (isPrismaErrorCode(error, "P2002")) {
+        return jsonError(
+          409,
+          "VARIANT_NAME_CONFLICT",
+          "A beer variant with that name already exists for this brand.",
+        );
+      }
+
+      if (isPrismaErrorCode(error, "P2003")) {
+        return jsonError(404, "RELATION_NOT_FOUND", "The specified style does not exist.");
+      }
+
+      throw error;
+    }
 
     if (!result) {
       return jsonError(404, "VARIANT_NOT_FOUND", `No variant found for id '${variantId}'.`);
@@ -46,7 +65,21 @@ async function deleteHandler(
 ): Promise<Response> {
   return withApiAdmin(async (admin) => {
     const { variantId } = await context.params;
-    const result = await deleteModerationVariant(variantId);
+    let result;
+
+    try {
+      result = await deleteModerationVariant(variantId);
+    } catch (error) {
+      if (isPrismaErrorCode(error, "P2003")) {
+        return jsonError(
+          409,
+          "VARIANT_IN_USE",
+          "This beer variant is still in use and cannot be deleted.",
+        );
+      }
+
+      throw error;
+    }
 
     if (!result.deleted) {
       return jsonError(404, "VARIANT_NOT_FOUND", `No variant found for id '${variantId}'.`);

--- a/src/app/api/v1/test/auth-links/route.ts
+++ b/src/app/api/v1/test/auth-links/route.ts
@@ -1,12 +1,10 @@
 import { z } from "zod";
-import { createEmailVerificationToken, requestPasswordReset } from "@/lib/auth";
-import { db } from "@/lib/db";
 import { jsonError, jsonOk } from "@/lib/http";
 import { withMetrics } from "@/lib/route-handlers";
-import { buildPasswordResetUrl, buildVerificationUrl } from "@/lib/verification";
+import { getLatestCapturedTestEmail } from "@/lib/test-email";
 
 const authLinkBodySchema = z.object({
-  kind: z.enum(["verification", "password_reset"]),
+  kind: z.enum(["verification", "change_email_verification", "password_reset"]),
   email: z.string().trim().email().max(255),
 });
 
@@ -29,27 +27,26 @@ async function createAuthLinkHandler(request: Request): Promise<Response> {
     return jsonError(400, "INVALID_BODY", "A valid request body is required.");
   }
 
-  if (parsed.data.kind === "verification") {
-    const user = await db.user.findUnique({
-      where: { email: parsed.data.email },
-      select: { id: true },
-    });
+  const email = getLatestCapturedTestEmail({
+    kind: parsed.data.kind,
+    to: parsed.data.email,
+  });
 
-    if (!user) {
-      return jsonError(404, "USER_NOT_FOUND", "No user found for the supplied email address.");
-    }
-
-    const token = await createEmailVerificationToken(user.id);
-    return jsonOk({ url: buildVerificationUrl(request, token) });
+  if (!email) {
+    return jsonError(404, "AUTH_EMAIL_NOT_FOUND", "No captured auth email found.");
   }
 
-  const result = await requestPasswordReset(parsed.data.email);
-
-  if (!result.ok) {
-    return jsonError(404, "USER_NOT_FOUND", "No user found for the supplied email address.");
-  }
-
-  return jsonOk({ url: buildPasswordResetUrl(request, result.token) });
+  return jsonOk({
+    url: email.actionUrl,
+    email: {
+      kind: email.kind,
+      to: email.to,
+      subject: email.subject,
+      text: email.text,
+      html: email.html,
+      createdAt: email.createdAt.toISOString(),
+    },
+  });
 }
 
 export const POST = withMetrics("POST", "/api/v1/test/auth-links", createAuthLinkHandler);

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { createTransport } from "nodemailer";
 import { logger } from "@/lib/logger";
+import { captureTestEmail, isTestEmailCaptureEnabled } from "@/lib/test-email";
 
 function isSmtpConfigured(): boolean {
   return Boolean(process.env.SMTP_HOST);
@@ -28,6 +29,19 @@ export async function sendVerificationEmail(to: string, verificationUrl: string)
 <p>This link expires in <strong>24 hours</strong>.</p>
 <p>If you did not create an account, you can safely ignore this email.</p>
 `.trim();
+
+  if (isTestEmailCaptureEnabled()) {
+    captureTestEmail({
+      kind: "verification",
+      to,
+      subject,
+      text,
+      html,
+      actionUrl: verificationUrl,
+    });
+    logger.info("Verification email captured for testing", { to });
+    return;
+  }
 
   if (!isSmtpConfigured()) {
     logger.info("Email verification (SMTP not configured — logging link instead)", {
@@ -83,6 +97,19 @@ export async function sendEmailChangeVerificationEmail(
 <p>If you did not request this change, you can safely ignore this email.</p>
 `.trim();
 
+  if (isTestEmailCaptureEnabled()) {
+    captureTestEmail({
+      kind: "change_email_verification",
+      to,
+      subject,
+      text,
+      html,
+      actionUrl: verificationUrl,
+    });
+    logger.info("Email change verification email captured for testing", { to });
+    return;
+  }
+
   if (!isSmtpConfigured()) {
     logger.info("Email change verification (SMTP not configured — logging link instead)", {
       to,
@@ -133,6 +160,19 @@ export async function sendPasswordResetEmail(to: string, resetUrl: string): Prom
 <p>This link expires in <strong>1 hour</strong>.</p>
 <p>If you did not request a password reset, you can safely ignore this email.</p>
 `.trim();
+
+  if (isTestEmailCaptureEnabled()) {
+    captureTestEmail({
+      kind: "password_reset",
+      to,
+      subject,
+      text,
+      html,
+      actionUrl: resetUrl,
+    });
+    logger.info("Password reset email captured for testing", { to });
+    return;
+  }
 
   if (!isSmtpConfigured()) {
     logger.info("Password reset (SMTP not configured — logging link instead)", {

--- a/src/lib/prisma-errors.ts
+++ b/src/lib/prisma-errors.ts
@@ -4,9 +4,48 @@ export function isKnownPrismaError(error: unknown): error is Prisma.PrismaClient
   return error instanceof Prisma.PrismaClientKnownRequestError;
 }
 
-export function isPrismaErrorCode(
-  error: unknown,
-  code: string,
-): error is Prisma.PrismaClientKnownRequestError {
-  return isKnownPrismaError(error) && error.code === code;
+function mapAdapterCodeToPrismaLikeCode(code: string | undefined): string | null {
+  if (!code) {
+    return null;
+  }
+
+  if (code === "23505") {
+    return "P2002";
+  }
+
+  if (code === "23503" || code === "23001") {
+    return "P2003";
+  }
+
+  return null;
+}
+
+function getAdapterErrorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null) {
+    return undefined;
+  }
+
+  if ("cause" in error && typeof error.cause === "object" && error.cause !== null) {
+    if ("originalCode" in error.cause && typeof error.cause.originalCode === "string") {
+      return error.cause.originalCode;
+    }
+
+    if ("code" in error.cause && typeof error.cause.code === "string") {
+      return error.cause.code;
+    }
+  }
+
+  if ("originalCode" in error && typeof error.originalCode === "string") {
+    return error.originalCode;
+  }
+
+  return undefined;
+}
+
+export function isPrismaErrorCode(error: unknown, code: string): boolean {
+  if (isKnownPrismaError(error)) {
+    return error.code === code;
+  }
+
+  return mapAdapterCodeToPrismaLikeCode(getAdapterErrorCode(error)) === code;
 }

--- a/src/lib/test-email.ts
+++ b/src/lib/test-email.ts
@@ -1,0 +1,80 @@
+import "server-only";
+
+export type TestEmailKind = "verification" | "change_email_verification" | "password_reset";
+
+export type CapturedTestEmail = {
+  kind: TestEmailKind;
+  to: string;
+  subject: string;
+  text: string;
+  html: string;
+  actionUrl: string;
+  createdAt: Date;
+};
+
+type TestEmailStore = {
+  messages: CapturedTestEmail[];
+};
+
+const MAX_CAPTURED_TEST_EMAILS = 100;
+
+function getStore(): TestEmailStore {
+  const globalStore = globalThis as typeof globalThis & {
+    __kbiTestEmailStore?: TestEmailStore;
+  };
+
+  if (!globalStore.__kbiTestEmailStore) {
+    globalStore.__kbiTestEmailStore = { messages: [] };
+  }
+
+  return globalStore.__kbiTestEmailStore;
+}
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export function isTestEmailCaptureEnabled(): boolean {
+  return process.env.E2E_TEST_MODE === "true" || process.env.TEST_EMAIL_CAPTURE === "true";
+}
+
+export function captureTestEmail(
+  email: Omit<CapturedTestEmail, "createdAt" | "to"> & { to: string },
+): CapturedTestEmail {
+  const captured: CapturedTestEmail = {
+    ...email,
+    to: normalizeEmail(email.to),
+    createdAt: new Date(),
+  };
+
+  const store = getStore();
+  store.messages.push(captured);
+
+  if (store.messages.length > MAX_CAPTURED_TEST_EMAILS) {
+    store.messages.splice(0, store.messages.length - MAX_CAPTURED_TEST_EMAILS);
+  }
+
+  return captured;
+}
+
+export function getLatestCapturedTestEmail(filter: {
+  kind: TestEmailKind;
+  to: string;
+}): CapturedTestEmail | null {
+  const to = normalizeEmail(filter.to);
+  const messages = getStore().messages;
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+
+    if (message.kind === filter.kind && message.to === to) {
+      return message;
+    }
+  }
+
+  return null;
+}
+
+export function clearCapturedTestEmails(): void {
+  getStore().messages.length = 0;
+}

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,25 @@
+# Test Helpers
+
+Shared test support lives in `test/` so unit, integration, and e2e suites can build data consistently.
+
+## Entry Point
+
+Import shared helpers from `test/index.ts` when you need reusable builders or DB cleanup utilities.
+
+## Factories
+
+- `createTestNamespace(scope)` creates a unique prefix for ids, names, and emails.
+- `buildCatalogFixture(namespace, label, overrides)` creates a linked style -> brand -> variant -> location -> offer fixture in memory.
+- Use the lower-level `buildUser`, `buildLocation`, `buildBeerStyle`, `buildBeerBrand`, `buildBeerVariant`, and `buildBeerOffer` builders when a test needs custom relationships.
+
+## Database Reset
+
+- `createTestDatabasePool()` creates a raw Postgres pool for database-backed test setup and cleanup.
+- `cleanupTestData(pool, options)` removes namespaced rows deterministically across auth, moderation, catalog, and report tables.
+- Prefer prefix-based cleanup (`idPrefixes`, `namePrefixes`) for integration runs and explicit ids/emails for long-lived e2e fixtures.
+
+## Integration Helpers
+
+- `integration-tests/helpers.ts` adds `seedCatalogFixture(...)` for persisting linked catalog fixtures with one call.
+- `integration-tests/helpers.ts` adds `seedCatalogOfferFixture(...)` when a test needs the linked fixture plus a guaranteed persisted offer.
+- Use `seedCatalogFixture(..., { offer: false })` when a test needs style/brand/variant/location without an initial offer row.

--- a/test/database-reset.ts
+++ b/test/database-reset.ts
@@ -1,0 +1,162 @@
+import pg from "pg";
+
+type CleanupTestDataOptions = {
+  idPrefixes?: string[];
+  namePrefixes?: string[];
+  userIds?: string[];
+  userEmails?: string[];
+};
+
+function unique(values: readonly string[] | undefined): string[] {
+  if (!values) {
+    return [];
+  }
+
+  return [...new Set(values.filter((value) => value.length > 0))];
+}
+
+function toStartsWithPatterns(values: readonly string[] | undefined): string[] {
+  return unique(values).map((value) => `${value}%`);
+}
+
+export function createTestDatabasePool(connectionString = process.env.DATABASE_URL): pg.Pool {
+  if (!connectionString) {
+    throw new Error("DATABASE_URL must be set before running database-backed tests.");
+  }
+
+  return new pg.Pool({ connectionString });
+}
+
+export async function cleanupTestData(
+  pool: pg.Pool,
+  options: CleanupTestDataOptions,
+): Promise<void> {
+  const idPatterns = toStartsWithPatterns(options.idPrefixes);
+  const namePatterns = toStartsWithPatterns(options.namePrefixes);
+  const userIds = unique(options.userIds);
+  const userEmails = unique(options.userEmails);
+
+  await pool.query(
+    `DELETE FROM "Report"
+     WHERE "contentId" LIKE ANY($1::text[])
+        OR "reporterId" LIKE ANY($1::text[])
+        OR "resolvedById" LIKE ANY($1::text[])
+        OR "snapshotAuthorId" LIKE ANY($1::text[])
+        OR "reporterId" = ANY($2::text[])
+        OR "resolvedById" = ANY($2::text[])
+        OR "snapshotAuthorId" = ANY($2::text[])`,
+    [idPatterns, userIds],
+  );
+
+  await pool.query(
+    `DELETE FROM "ModerationAuditLog"
+     WHERE "contentId" LIKE ANY($1::text[])
+        OR "moderatorId" LIKE ANY($1::text[])
+        OR "moderatorId" = ANY($2::text[])
+        OR "moderatorName" LIKE ANY($3::text[])`,
+    [idPatterns, userIds, namePatterns],
+  );
+
+  await pool.query(
+    `DELETE FROM "Review"
+     WHERE id LIKE ANY($1::text[])
+        OR "locationId" LIKE ANY($1::text[])
+        OR "userId" LIKE ANY($1::text[])
+        OR "userId" = ANY($2::text[])`,
+    [idPatterns, userIds],
+  );
+
+  await pool.query(
+    `DELETE FROM "OfferPriceHistory"
+     WHERE id LIKE ANY($1::text[])
+        OR "beerOfferId" LIKE ANY($1::text[])
+        OR "priceUpdateProposalId" LIKE ANY($1::text[])`,
+    [idPatterns],
+  );
+
+  await pool.query(
+    `DELETE FROM "PriceUpdateProposal"
+     WHERE id LIKE ANY($1::text[])
+        OR "beerOfferId" LIKE ANY($1::text[])
+        OR "createdById" LIKE ANY($1::text[])
+        OR "createdById" = ANY($2::text[])`,
+    [idPatterns, userIds],
+  );
+
+  await pool.query(
+    `DELETE FROM "BeerOffer"
+     WHERE id LIKE ANY($1::text[])
+        OR "locationId" LIKE ANY($1::text[])
+        OR "variantId" LIKE ANY($1::text[])
+        OR "createdById" LIKE ANY($1::text[])
+        OR "createdById" = ANY($2::text[])
+        OR brand LIKE ANY($3::text[])
+        OR variant LIKE ANY($3::text[])`,
+    [idPatterns, userIds, namePatterns],
+  );
+
+  await pool.query(
+    `DELETE FROM "BeerVariant"
+     WHERE id LIKE ANY($1::text[])
+        OR "brandId" LIKE ANY($1::text[])
+        OR "styleId" LIKE ANY($1::text[])
+        OR "createdById" LIKE ANY($1::text[])
+        OR "createdById" = ANY($2::text[])
+        OR name LIKE ANY($3::text[])`,
+    [idPatterns, userIds, namePatterns],
+  );
+
+  await pool.query(
+    `DELETE FROM "BeerBrand"
+     WHERE id LIKE ANY($1::text[])
+        OR "createdById" LIKE ANY($1::text[])
+        OR "createdById" = ANY($2::text[])
+        OR name LIKE ANY($3::text[])`,
+    [idPatterns, userIds, namePatterns],
+  );
+
+  await pool.query(
+    `DELETE FROM "BeerStyle"
+     WHERE id LIKE ANY($1::text[])
+        OR name LIKE ANY($2::text[])`,
+    [idPatterns, namePatterns],
+  );
+
+  await pool.query(
+    `DELETE FROM "Location"
+     WHERE id LIKE ANY($1::text[])
+        OR "createdById" LIKE ANY($1::text[])
+        OR "createdById" = ANY($2::text[])
+        OR name LIKE ANY($3::text[])`,
+    [idPatterns, userIds, namePatterns],
+  );
+
+  await pool.query(
+    `DELETE FROM "Session"
+     WHERE "userId" LIKE ANY($1::text[])
+        OR "userId" = ANY($2::text[])`,
+    [idPatterns, userIds],
+  );
+  await pool.query(
+    `DELETE FROM "EmailVerificationToken"
+     WHERE "userId" LIKE ANY($1::text[])
+        OR "userId" = ANY($2::text[])`,
+    [idPatterns, userIds],
+  );
+  await pool.query(
+    `DELETE FROM "PasswordResetToken"
+     WHERE "userId" LIKE ANY($1::text[])
+        OR "userId" = ANY($2::text[])`,
+    [idPatterns, userIds],
+  );
+
+  await pool.query(
+    `DELETE FROM "User"
+     WHERE id LIKE ANY($3::text[])
+        OR id = ANY($1::text[])
+        OR email = ANY($2::text[])
+        OR email LIKE ANY($3::text[])
+        OR "displayName" LIKE ANY($4::text[])`,
+    [userIds, userEmails, idPatterns, namePatterns],
+  );
+}

--- a/test/factories/index.ts
+++ b/test/factories/index.ts
@@ -168,3 +168,42 @@ export function buildBeerOffer(
     ...overrides,
   };
 }
+
+export function buildCatalogFixture(
+  namespace: TestNamespace,
+  label: string,
+  overrides: Partial<{
+    style: Parameters<typeof buildBeerStyle>[2];
+    brand: Parameters<typeof buildBeerBrand>[2];
+    variant: Parameters<typeof buildBeerVariant>[2];
+    location: Parameters<typeof buildLocation>[2];
+    offer: false | Parameters<typeof buildBeerOffer>[2];
+  }> = {},
+) {
+  const style = buildBeerStyle(namespace, `${label} style`, overrides.style);
+  const brand = buildBeerBrand(namespace, `${label} brand`, overrides.brand);
+  const variant = buildBeerVariant(namespace, `${label} variant`, {
+    brandId: brand.id,
+    styleId: style.id,
+    ...overrides.variant,
+  });
+  const location = buildLocation(namespace, `${label} location`, overrides.location);
+  const offer =
+    overrides.offer === false
+      ? undefined
+      : buildBeerOffer(namespace, `${label} offer`, {
+          brand: brand.name,
+          variant: variant.name,
+          variantId: variant.id,
+          locationId: location.id,
+          ...overrides.offer,
+        });
+
+  return {
+    style,
+    brand,
+    variant,
+    location,
+    offer,
+  };
+}

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,2 @@
+export * from "./database-reset";
+export * from "./factories";


### PR DESCRIPTION
# Important Changes

- **Auth Integration Tests**: Added comprehensive auth integration tests with server-only mocking for password management, email verification, and user profile updates
- **Prisma Error Handling**: Added error handling for variant and style operations with constraint violation mapping and integration tests
- **Moderation Audit Logs**: Added tests verifying audit log creation for moderation offer approvals and rejections
- **Database Persistence**: Added assertions validating beer offers and price proposals are correctly persisted with expected values
- **E2E Data Seeding**: Automated baseline data seeding in Playwright global setup to eliminate manual db:seed dependency
- **Test Utilities Extraction**: Extracted shared authentication helpers, test suffixes, and catalog fixture builders to reduce duplication
- **Test Helpers & Fixtures**: Added seedCatalogFixture and seedCatalogOfferFixture helpers to simplify integration test setup
- **Authorization Mocks**: Expanded test mocks with type definitions for AuthUser and ReportRecord, added mocks for location reviews, reports, and moderation endpoints
- **Email Capture System**: Implemented test email capture module for e2e testing with verification link retrieval
- **E2E Moderator Tests**: Added tests for moderator editing/rejecting location submissions and editing/deleting offer submissions
- **Pending Item Workflow**: Added e2e test verifying users can submit pending brands/variants and use them in offer forms