### PR TITLE
add-contract-test-filtering-route-switch-proxy

### DIFF
--- a/__tests__/scripts/local-route-switch.test.ts
+++ b/__tests__/scripts/local-route-switch.test.ts
@@ -1,0 +1,331 @@
+import { spawn, type ChildProcessByStdio } from "node:child_process";
+import {
+  createServer,
+  request as httpRequest,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+import { once } from "node:events";
+import { resolve } from "node:path";
+import type { Readable } from "node:stream";
+import { gzipSync } from "node:zlib";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+jest.setTimeout(15_000);
+
+type RequestHandler = (request: IncomingMessage, response: ServerResponse) => void | Promise<void>;
+
+type FixtureServer = {
+  server: Server;
+  url: string;
+};
+
+type ProxyProcess = {
+  child: ChildProcessByStdio<null, Readable, Readable>;
+  url: string;
+};
+
+type RawResponse = {
+  body: Buffer;
+  headers: IncomingMessage["headers"];
+  statusCode: number;
+};
+
+async function startFixtureServer(handler: RequestHandler): Promise<FixtureServer> {
+  const server = createServer((request, response) => {
+    Promise.resolve(handler(request, response)).catch((error: unknown) => {
+      response.destroy(error instanceof Error ? error : new Error(String(error)));
+    });
+  });
+
+  await new Promise<void>((resolvePromise, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolvePromise());
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Fixture server did not expose a TCP address.");
+  }
+
+  return { server, url: `http://127.0.0.1:${address.port}` };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) {
+    return;
+  }
+
+  await new Promise<void>((resolvePromise) => server.close(() => resolvePromise()));
+}
+
+async function findFreePort(): Promise<number> {
+  const fixture = await startFixtureServer((_request, response) => {
+    response.end();
+  });
+  const port = Number(new URL(fixture.url).port);
+  await closeServer(fixture.server);
+  return port;
+}
+
+async function startProxy(nextUrl: string, rustUrl: string): Promise<ProxyProcess> {
+  const port = await findFreePort();
+  const child = spawn(
+    process.execPath,
+    [resolve(process.cwd(), "scripts/local-route-switch.mjs")],
+    {
+      env: {
+        ...process.env,
+        NEXT_API_BASE_URL: nextUrl,
+        ROUTE_SWITCH_PORT: String(port),
+        RUST_API_BASE_URL: rustUrl,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+
+  let output = "";
+  const listeningPort = await new Promise<number>((resolvePromise, reject) => {
+    const onOutput = (chunk: Buffer | string) => {
+      output += chunk.toString();
+      if (
+        output.includes(`listening on http://localhost:${port}`) ||
+        output.includes(`listening on http://127.0.0.1:${port}`)
+      ) {
+        resolvePromise(port);
+      }
+    };
+
+    child.stdout.on("data", onOutput);
+    child.stderr.on("data", onOutput);
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      reject(new Error(`Route switch exited before listening (${code ?? signal}).\n${output}`));
+    });
+  });
+
+  return { child, url: `http://127.0.0.1:${listeningPort}` };
+}
+
+async function stopProxy(child: ChildProcessByStdio<null, Readable, Readable>): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+
+  await new Promise<void>((resolvePromise) => {
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      resolvePromise();
+    }, 1_000);
+
+    child.once("exit", () => {
+      clearTimeout(timer);
+      resolvePromise();
+    });
+    child.kill("SIGTERM");
+  });
+}
+
+async function requestRaw(
+  baseUrl: string,
+  options: {
+    body?: Buffer;
+    headers?: Record<string, string>;
+    method?: string;
+    path?: string;
+  } = {},
+): Promise<RawResponse> {
+  const target = new URL(baseUrl);
+
+  return new Promise<RawResponse>((resolvePromise, reject) => {
+    const request = httpRequest(
+      {
+        headers: options.headers,
+        hostname: target.hostname,
+        method: options.method ?? "GET",
+        path: options.path ?? `${target.pathname}${target.search}`,
+        port: target.port,
+      },
+      (response) => {
+        const chunks: Buffer[] = [];
+        response.on("data", (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+        response.on("end", () => {
+          resolvePromise({
+            body: Buffer.concat(chunks),
+            headers: response.headers,
+            statusCode: response.statusCode ?? 0,
+          });
+        });
+        response.on("error", reject);
+      },
+    );
+
+    request.on("error", reject);
+    if (options.body) {
+      request.write(options.body);
+    }
+    request.end();
+  });
+}
+
+async function readSlowly(baseUrl: string, path: string): Promise<Buffer> {
+  const target = new URL(baseUrl);
+
+  return new Promise<Buffer>((resolvePromise, reject) => {
+    const request = httpRequest(
+      {
+        hostname: target.hostname,
+        path,
+        port: target.port,
+      },
+      (response) => {
+        const chunks: Buffer[] = [];
+        response.on("data", (chunk: Buffer) => {
+          response.pause();
+          chunks.push(Buffer.from(chunk));
+          setTimeout(() => response.resume(), 1);
+        });
+        response.on("end", () => resolvePromise(Buffer.concat(chunks)));
+        response.on("error", reject);
+      },
+    );
+
+    request.on("error", reject);
+    request.end();
+  });
+}
+
+describe("local route switch", () => {
+  let nextServer!: FixtureServer;
+  let rustServer!: FixtureServer;
+  let attackerServer!: FixtureServer;
+  let proxy!: ProxyProcess;
+  let rustPaths: string[];
+  let attackerHits: number;
+  let nextRequestBody: Buffer | undefined;
+  let nextRequestEncoding: string | undefined;
+
+  beforeAll(async () => {
+    nextServer = await startFixtureServer(async (request, response) => {
+      if (request.url === "/cookies") {
+        response.writeHead(200, {
+          "content-type": "text/plain",
+          "set-cookie": ["first=one; Path=/", "second=two; Path=/"],
+        });
+        response.end("cookies");
+        return;
+      }
+
+      if (request.url === "/large") {
+        const chunk = Buffer.alloc(64 * 1024, "x");
+        response.writeHead(200, { "content-type": "application/octet-stream" });
+        for (let index = 0; index < 32; index += 1) {
+          if (!response.write(chunk)) {
+            await once(response, "drain");
+          }
+        }
+        response.end();
+        return;
+      }
+
+      if (request.method === "POST" && request.url === "/api/v1/beers") {
+        const chunks: Buffer[] = [];
+        request.on("data", (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+        await once(request, "end");
+        nextRequestBody = Buffer.concat(chunks);
+        nextRequestEncoding = request.headers["content-encoding"];
+      }
+
+      response.writeHead(200, { "content-type": "text/plain" });
+      response.end("next");
+    });
+
+    rustServer = await startFixtureServer((request, response) => {
+      rustPaths.push(request.url ?? "/");
+      response.writeHead(200, { "content-type": "text/plain" });
+      response.end("rust");
+    });
+
+    attackerServer = await startFixtureServer((_request, response) => {
+      attackerHits += 1;
+      response.writeHead(200, { "content-type": "text/plain" });
+      response.end("attacker");
+    });
+
+    proxy = await startProxy(nextServer.url, rustServer.url);
+  });
+
+  beforeEach(() => {
+    rustPaths = [];
+    attackerHits = 0;
+    nextRequestBody = undefined;
+    nextRequestEncoding = undefined;
+  });
+
+  afterAll(async () => {
+    if (proxy) {
+      await stopProxy(proxy.child);
+    }
+    if (nextServer) {
+      await closeServer(nextServer.server);
+    }
+    if (rustServer) {
+      await closeServer(rustServer.server);
+    }
+    if (attackerServer) {
+      await closeServer(attackerServer.server);
+    }
+  });
+
+  it("routes the explicit Rust method and path allowlist", async () => {
+    const health = await requestRaw(proxy.url, { path: "/api/v1/health" });
+    const styles = await requestRaw(proxy.url, { path: "/api/v1/beer-styles" });
+    const beers = await requestRaw(proxy.url, { path: "/api/v1/beers" });
+
+    expect(health.body.toString()).toBe("rust");
+    expect(styles.body.toString()).toBe("rust");
+    expect(beers.body.toString()).toBe("next");
+    expect(rustPaths).toEqual(["/api/v1/health", "/api/v1/beer-styles"]);
+  });
+
+  it("preserves content encoding and compressed request bytes", async () => {
+    const body = gzipSync(Buffer.from('{"name":"test"}'));
+    const response = await requestRaw(proxy.url, {
+      body,
+      headers: {
+        "content-encoding": "gzip",
+        "content-length": String(body.length),
+        "content-type": "application/json",
+      },
+      method: "POST",
+      path: "/api/v1/beers",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(nextRequestEncoding).toBe("gzip");
+    expect(nextRequestBody).toEqual(body);
+  });
+
+  it("forwards multiple Set-Cookie headers separately", async () => {
+    const response = await requestRaw(proxy.url, { path: "/cookies" });
+
+    expect(response.headers["set-cookie"]).toEqual(["first=one; Path=/", "second=two; Path=/"]);
+  });
+
+  it("streams a large response completely to a slow client", async () => {
+    const body = await readSlowly(proxy.url, "/large");
+
+    expect(body.length).toBe(2 * 1024 * 1024);
+    expect(body.every((byte) => byte === 120)).toBe(true);
+  });
+
+  it("rejects absolute-form request targets", async () => {
+    const response = await requestRaw(proxy.url, {
+      path: `${attackerServer.url}/secret`,
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(attackerHits).toBe(0);
+  });
+});

--- a/contract-tests/README.md
+++ b/contract-tests/README.md
@@ -32,6 +32,26 @@ npm run test:contract:parity
 
 The same `CONTRACT_TEST_PATTERN` filter works in parity mode, which is useful while Rust only implements a subset of the route inventory.
 
+## Local Route Switching
+
+When Next.js and Rust are both running locally, start the small route switch proxy:
+
+```sh
+npm run route-switch:dev
+```
+
+By default, it listens on `http://localhost:3100`, sends `GET /api/v1/health` to Rust at `http://localhost:4000`, and sends every other request to Next.js at `http://localhost:3000`.
+
+Run contracts against the switched stable URL:
+
+```sh
+API_BASE_URL=http://localhost:3100 \
+CONTRACT_TEST_PATTERN="/api/v1/health" \
+npm run test:contract
+```
+
+The defaults can be overridden with `ROUTE_SWITCH_PORT`, `NEXT_API_BASE_URL`, and `RUST_API_BASE_URL`.
+
 ## Adding A Route
 
 1. Add a contract file in `contract-tests/contracts/`.

--- a/contract-tests/README.md
+++ b/contract-tests/README.md
@@ -14,6 +14,14 @@ API_BASE_URL=http://localhost:3000 npm run test:contract
 API_BASE_URL=http://localhost:4000 npm run test:contract
 ```
 
+Run a route slice by matching comma-separated substrings against the contract name or request path:
+
+```sh
+CONTRACT_TEST_PATTERN="/api/v1/health,/api/v1/metrics,/api/v1/beer-styles" \
+API_BASE_URL=http://localhost:4000 \
+npm run test:contract
+```
+
 Compare Next.js and Rust responses for parity:
 
 ```sh
@@ -21,6 +29,8 @@ NEXT_API_BASE_URL=http://localhost:3000 \
 RUST_API_BASE_URL=http://localhost:4000 \
 npm run test:contract:parity
 ```
+
+The same `CONTRACT_TEST_PATTERN` filter works in parity mode, which is useful while Rust only implements a subset of the route inventory.
 
 ## Adding A Route
 

--- a/contract-tests/README.md
+++ b/contract-tests/README.md
@@ -40,13 +40,15 @@ When Next.js and Rust are both running locally, start the small route switch pro
 npm run route-switch:dev
 ```
 
-By default, it listens on `http://localhost:3100`, sends `GET /api/v1/health` to Rust at `http://localhost:4000`, and sends every other request to Next.js at `http://localhost:3000`.
+By default, it listens only on `http://127.0.0.1:3100`, sends `GET /api/v1/health` and `GET /api/v1/beer-styles` to Rust at `http://localhost:4000`, and sends every other request to Next.js at `http://localhost:3000`.
+
+The Rust routes are an explicit method/path allowlist in `scripts/local-route-switch.mjs`. The proxy port and upstream base URLs are configurable; route patterns are not.
 
 Run contracts against the switched stable URL:
 
 ```sh
 API_BASE_URL=http://localhost:3100 \
-CONTRACT_TEST_PATTERN="/api/v1/health" \
+CONTRACT_TEST_PATTERN="/api/v1/health,/api/v1/beer-styles" \
 npm run test:contract
 ```
 

--- a/contract-tests/contracts/inventory.ts
+++ b/contract-tests/contracts/inventory.ts
@@ -80,12 +80,24 @@ export const publicCatalogContracts: ContractCase[] = [
     assert(response) {
       assertEqual(response.status, 200, "Expected metrics endpoint to return 200.");
       assertString(response.body, "Expected Prometheus metrics text body.");
-      assert(response.body.includes("# HELP"), "Expected Prometheus HELP lines.");
+      assert(response.body.includes("# TYPE"), "Expected Prometheus TYPE lines.");
+      assertString(response.headers["content-type"], "Expected metrics content type header.");
+      assert(
+        response.headers["content-type"].startsWith("text/plain; version=0.0.4"),
+        "Expected Prometheus text content type.",
+      );
       assertEqual(
         response.headers["cache-control"],
         "no-cache",
         "Expected no-cache metrics header.",
       );
+    },
+    normalize(response) {
+      return {
+        ...response,
+        headers: { ...response.headers, "content-type": "text/plain; version=0.0.4" },
+        body: "<prometheus-metrics>",
+      };
     },
   },
   publicOkContract(

--- a/contract-tests/parity.ts
+++ b/contract-tests/parity.ts
@@ -9,9 +9,18 @@ import {
 } from "./fixtures";
 import { sendContractRequest } from "./http";
 import { normalizeHeaders } from "./normalize";
+import { describeContractSelection, selectContracts } from "./select";
 import type { ContractCase, ContractResponse } from "./types";
 
-const VOLATILE_HEADERS = ["connection", "date", "keep-alive", "transfer-encoding", "x-request-id"];
+const VOLATILE_HEADERS = [
+  "connection",
+  "content-encoding",
+  "date",
+  "keep-alive",
+  "transfer-encoding",
+  "vary",
+  "x-request-id",
+];
 
 async function sendWithFreshFixtures(
   baseUrl: string,
@@ -42,10 +51,13 @@ async function main(): Promise<void> {
     );
   }
 
+  const selectedContracts = selectContracts(contracts);
   let passed = 0;
 
+  console.log(describeContractSelection(contracts.length, selectedContracts.length));
+
   try {
-    for (const contract of contracts) {
+    for (const contract of selectedContracts) {
       const nextResponse = await sendWithFreshFixtures(nextApiBaseUrl, contract);
       await contract.assert(nextResponse, { baseUrl: nextApiBaseUrl });
 

--- a/contract-tests/run.ts
+++ b/contract-tests/run.ts
@@ -5,15 +5,19 @@ import {
   setupContractFixtures,
 } from "./fixtures";
 import { sendContractRequest } from "./http";
+import { describeContractSelection, selectContracts } from "./select";
 
 async function main(): Promise<void> {
   const apiBaseUrl = process.env.API_BASE_URL ?? "http://localhost:3000";
+  const selectedContracts = selectContracts(contracts);
   let passed = 0;
+
+  console.log(describeContractSelection(contracts.length, selectedContracts.length));
 
   await setupContractFixtures();
 
   try {
-    for (const contract of contracts) {
+    for (const contract of selectedContracts) {
       const response = await sendContractRequest(apiBaseUrl, contract.request);
       await contract.assert(response, { baseUrl: apiBaseUrl });
       passed += 1;

--- a/contract-tests/select.ts
+++ b/contract-tests/select.ts
@@ -1,0 +1,44 @@
+import type { ContractCase } from "./types";
+
+const PATTERN_ENV = "CONTRACT_TEST_PATTERN";
+
+function parsePatterns(value: string | undefined): string[] {
+  return (value ?? "")
+    .split(",")
+    .map((pattern) => pattern.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function matchesPattern(contract: ContractCase, pattern: string): boolean {
+  return (
+    contract.name.toLowerCase().includes(pattern) ||
+    contract.request.path.toLowerCase().includes(pattern)
+  );
+}
+
+export function selectContracts(contracts: ContractCase[]): ContractCase[] {
+  const patterns = parsePatterns(process.env[PATTERN_ENV]);
+
+  if (patterns.length === 0) {
+    return contracts;
+  }
+
+  const selected = contracts.filter((contract) =>
+    patterns.some((pattern) => matchesPattern(contract, pattern)),
+  );
+
+  if (selected.length === 0) {
+    throw new Error(`${PATTERN_ENV} did not match any contract. Patterns: ${patterns.join(", ")}`);
+  }
+
+  return selected;
+}
+
+export function describeContractSelection(total: number, selected: number): string {
+  const pattern = process.env[PATTERN_ENV];
+  if (!pattern) {
+    return `Running ${selected} contract(s).`;
+  }
+
+  return `Running ${selected} of ${total} contract(s) matching ${PATTERN_ENV}=${JSON.stringify(pattern)}.`;
+}

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -71,75 +71,75 @@ Query-bearing routes that validate query params use:
 
 Owner describes the current implementation owner. Status describes the Rust migration state, not whether the route exists today.
 
-| Method | Path                                       | Auth             | Owner   | Status     | Contract Test |
-| ------ | ------------------------------------------ | ---------------- | ------- | ---------- | ------------- |
-| GET    | `/health`                                  | Public           | Next.js | Unmigrated | Covered       |
-| GET    | `/metrics`                                 | Public           | Next.js | Unmigrated | Covered       |
-| GET    | `/beers`                                   | Public           | Next.js | Unmigrated | Covered       |
-| POST   | `/beers`                                   | Authenticated    | Next.js | Unmigrated | Covered       |
-| GET    | `/beer-styles`                             | Public           | Next.js | Unmigrated | Covered       |
-| GET    | `/beer-brands`                             | Public           | Next.js | Unmigrated | Covered       |
-| POST   | `/beer-brands`                             | Authenticated    | Next.js | Unmigrated | Covered       |
-| GET    | `/beer-variants`                           | Public           | Next.js | Unmigrated | Covered       |
-| POST   | `/beer-variants`                           | Authenticated    | Next.js | Unmigrated | Covered       |
-| POST   | `/locations`                               | Authenticated    | Next.js | Unmigrated | Covered       |
-| GET    | `/locations/:locationId`                   | Public           | Next.js | Unmigrated | Covered       |
-| GET    | `/reviews`                                 | Public           | Next.js | Unmigrated | Covered       |
-| POST   | `/reviews`                                 | Authenticated    | Next.js | Unmigrated | Covered       |
-| PATCH  | `/reviews/:reviewId`                       | Authenticated    | Next.js | Unmigrated | Covered       |
-| DELETE | `/reviews/:reviewId`                       | Authenticated    | Next.js | Unmigrated | Covered       |
-| POST   | `/reports`                                 | Authenticated    | Next.js | Unmigrated | Covered       |
-| POST   | `/auth/register`                           | Public           | Next.js | Unmigrated | Covered       |
-| POST   | `/auth/login`                              | Public           | Next.js | Unmigrated | Covered       |
-| POST   | `/auth/logout`                             | Public           | Next.js | Unmigrated | Covered       |
-| GET    | `/auth/session`                            | Optional session | Next.js | Unmigrated | Covered       |
-| GET    | `/auth/me`                                 | Authenticated    | Next.js | Unmigrated | Covered       |
-| GET    | `/auth/profile`                            | Authenticated    | Next.js | Unmigrated | Covered       |
-| PATCH  | `/auth/profile`                            | Authenticated    | Next.js | Unmigrated | Covered       |
-| POST   | `/auth/change-email`                       | Authenticated    | Next.js | Unmigrated | Covered       |
-| POST   | `/auth/resend-verification`                | Public           | Next.js | Unmigrated | Covered       |
-| GET    | `/auth/verify-email`                       | Public           | Next.js | Unmigrated | Covered       |
-| POST   | `/auth/verify-email`                       | Public           | Next.js | Unmigrated | Covered       |
-| POST   | `/auth/forgot-password`                    | Public           | Next.js | Unmigrated | Covered       |
-| POST   | `/auth/reset-password`                     | Public           | Next.js | Unmigrated | Covered       |
-| GET    | `/moderation/submissions`                  | Moderator        | Next.js | Unmigrated | Covered       |
-| GET    | `/moderation/audit-log`                    | Moderator        | Next.js | Unmigrated | Covered       |
-| GET    | `/moderation/reports`                      | Moderator        | Next.js | Unmigrated | Covered       |
-| PATCH  | `/moderation/reports/:reportId`            | Moderator        | Next.js | Unmigrated | Covered       |
-| PATCH  | `/moderation/locations/:locationId`        | Moderator        | Next.js | Unmigrated | Covered       |
-| PUT    | `/moderation/locations/:locationId`        | Moderator        | Next.js | Unmigrated | Covered       |
-| DELETE | `/moderation/locations/:locationId`        | Moderator        | Next.js | Unmigrated | Covered       |
-| PATCH  | `/moderation/brands/:brandId`              | Moderator        | Next.js | Unmigrated | Covered       |
-| DELETE | `/moderation/brands/:brandId`              | Moderator        | Next.js | Unmigrated | Covered       |
-| PATCH  | `/moderation/variants/:variantId`          | Moderator        | Next.js | Unmigrated | Covered       |
-| DELETE | `/moderation/variants/:variantId`          | Moderator        | Next.js | Unmigrated | Covered       |
-| PATCH  | `/moderation/offers/:offerId`              | Moderator        | Next.js | Unmigrated | Covered       |
-| PUT    | `/moderation/offers/:offerId`              | Moderator        | Next.js | Unmigrated | Covered       |
-| DELETE | `/moderation/offers/:offerId`              | Moderator        | Next.js | Unmigrated | Covered       |
-| PATCH  | `/moderation/price-updates/:proposalId`    | Moderator        | Next.js | Unmigrated | Covered       |
-| DELETE | `/moderation/price-updates/:proposalId`    | Moderator        | Next.js | Unmigrated | Covered       |
-| PATCH  | `/moderation/reviews/:reviewId`            | Moderator        | Next.js | Unmigrated | Covered       |
-| PUT    | `/moderation/reviews/:reviewId`            | Moderator        | Next.js | Unmigrated | Covered       |
-| DELETE | `/moderation/reviews/:reviewId`            | Moderator        | Next.js | Unmigrated | Covered       |
-| GET    | `/admin/users`                             | Admin            | Next.js | Unmigrated | Covered       |
-| DELETE | `/admin/users/:userId`                     | Admin            | Next.js | Unmigrated | Covered       |
-| PATCH  | `/admin/users/:userId/role`                | Admin            | Next.js | Unmigrated | Covered       |
-| POST   | `/admin/users/:userId/ban`                 | Admin            | Next.js | Unmigrated | Covered       |
-| POST   | `/admin/users/:userId/unban`               | Admin            | Next.js | Unmigrated | Covered       |
-| POST   | `/admin/users/:userId/verify`              | Admin            | Next.js | Unmigrated | Covered       |
-| POST   | `/admin/users/:userId/resend-verification` | Admin            | Next.js | Unmigrated | Covered       |
-| POST   | `/admin/styles`                            | Admin            | Next.js | Unmigrated | Covered       |
-| PUT    | `/admin/styles/:styleId`                   | Admin            | Next.js | Unmigrated | Covered       |
-| DELETE | `/admin/styles/:styleId`                   | Admin            | Next.js | Unmigrated | Covered       |
-| POST   | `/admin/brands`                            | Admin            | Next.js | Unmigrated | Covered       |
-| PUT    | `/admin/brands/:brandId`                   | Admin            | Next.js | Unmigrated | Covered       |
-| DELETE | `/admin/brands/:brandId`                   | Admin            | Next.js | Unmigrated | Covered       |
-| POST   | `/admin/variants`                          | Admin            | Next.js | Unmigrated | Covered       |
-| PUT    | `/admin/variants/:variantId`               | Admin            | Next.js | Unmigrated | Covered       |
-| DELETE | `/admin/variants/:variantId`               | Admin            | Next.js | Unmigrated | Covered       |
-| POST   | `/admin/locations`                         | Admin            | Next.js | Unmigrated | Covered       |
-| POST   | `/admin/offers`                            | Admin            | Next.js | Unmigrated | Covered       |
-| POST   | `/test/auth-links`                         | Test mode only   | Next.js | Unmigrated | Covered       |
+| Method | Path                                       | Auth             | Owner   | Status                       | Contract Test |
+| ------ | ------------------------------------------ | ---------------- | ------- | ---------------------------- | ------------- |
+| GET    | `/health`                                  | Public           | Next.js | Rust implemented, not routed | Covered       |
+| GET    | `/metrics`                                 | Public           | Next.js | Rust implemented, not routed | Covered       |
+| GET    | `/beers`                                   | Public           | Next.js | Unmigrated                   | Covered       |
+| POST   | `/beers`                                   | Authenticated    | Next.js | Unmigrated                   | Covered       |
+| GET    | `/beer-styles`                             | Public           | Next.js | Rust implemented, not routed | Covered       |
+| GET    | `/beer-brands`                             | Public           | Next.js | Unmigrated                   | Covered       |
+| POST   | `/beer-brands`                             | Authenticated    | Next.js | Unmigrated                   | Covered       |
+| GET    | `/beer-variants`                           | Public           | Next.js | Unmigrated                   | Covered       |
+| POST   | `/beer-variants`                           | Authenticated    | Next.js | Unmigrated                   | Covered       |
+| POST   | `/locations`                               | Authenticated    | Next.js | Unmigrated                   | Covered       |
+| GET    | `/locations/:locationId`                   | Public           | Next.js | Unmigrated                   | Covered       |
+| GET    | `/reviews`                                 | Public           | Next.js | Unmigrated                   | Covered       |
+| POST   | `/reviews`                                 | Authenticated    | Next.js | Unmigrated                   | Covered       |
+| PATCH  | `/reviews/:reviewId`                       | Authenticated    | Next.js | Unmigrated                   | Covered       |
+| DELETE | `/reviews/:reviewId`                       | Authenticated    | Next.js | Unmigrated                   | Covered       |
+| POST   | `/reports`                                 | Authenticated    | Next.js | Unmigrated                   | Covered       |
+| POST   | `/auth/register`                           | Public           | Next.js | Unmigrated                   | Covered       |
+| POST   | `/auth/login`                              | Public           | Next.js | Unmigrated                   | Covered       |
+| POST   | `/auth/logout`                             | Public           | Next.js | Unmigrated                   | Covered       |
+| GET    | `/auth/session`                            | Optional session | Next.js | Unmigrated                   | Covered       |
+| GET    | `/auth/me`                                 | Authenticated    | Next.js | Unmigrated                   | Covered       |
+| GET    | `/auth/profile`                            | Authenticated    | Next.js | Unmigrated                   | Covered       |
+| PATCH  | `/auth/profile`                            | Authenticated    | Next.js | Unmigrated                   | Covered       |
+| POST   | `/auth/change-email`                       | Authenticated    | Next.js | Unmigrated                   | Covered       |
+| POST   | `/auth/resend-verification`                | Public           | Next.js | Unmigrated                   | Covered       |
+| GET    | `/auth/verify-email`                       | Public           | Next.js | Unmigrated                   | Covered       |
+| POST   | `/auth/verify-email`                       | Public           | Next.js | Unmigrated                   | Covered       |
+| POST   | `/auth/forgot-password`                    | Public           | Next.js | Unmigrated                   | Covered       |
+| POST   | `/auth/reset-password`                     | Public           | Next.js | Unmigrated                   | Covered       |
+| GET    | `/moderation/submissions`                  | Moderator        | Next.js | Unmigrated                   | Covered       |
+| GET    | `/moderation/audit-log`                    | Moderator        | Next.js | Unmigrated                   | Covered       |
+| GET    | `/moderation/reports`                      | Moderator        | Next.js | Unmigrated                   | Covered       |
+| PATCH  | `/moderation/reports/:reportId`            | Moderator        | Next.js | Unmigrated                   | Covered       |
+| PATCH  | `/moderation/locations/:locationId`        | Moderator        | Next.js | Unmigrated                   | Covered       |
+| PUT    | `/moderation/locations/:locationId`        | Moderator        | Next.js | Unmigrated                   | Covered       |
+| DELETE | `/moderation/locations/:locationId`        | Moderator        | Next.js | Unmigrated                   | Covered       |
+| PATCH  | `/moderation/brands/:brandId`              | Moderator        | Next.js | Unmigrated                   | Covered       |
+| DELETE | `/moderation/brands/:brandId`              | Moderator        | Next.js | Unmigrated                   | Covered       |
+| PATCH  | `/moderation/variants/:variantId`          | Moderator        | Next.js | Unmigrated                   | Covered       |
+| DELETE | `/moderation/variants/:variantId`          | Moderator        | Next.js | Unmigrated                   | Covered       |
+| PATCH  | `/moderation/offers/:offerId`              | Moderator        | Next.js | Unmigrated                   | Covered       |
+| PUT    | `/moderation/offers/:offerId`              | Moderator        | Next.js | Unmigrated                   | Covered       |
+| DELETE | `/moderation/offers/:offerId`              | Moderator        | Next.js | Unmigrated                   | Covered       |
+| PATCH  | `/moderation/price-updates/:proposalId`    | Moderator        | Next.js | Unmigrated                   | Covered       |
+| DELETE | `/moderation/price-updates/:proposalId`    | Moderator        | Next.js | Unmigrated                   | Covered       |
+| PATCH  | `/moderation/reviews/:reviewId`            | Moderator        | Next.js | Unmigrated                   | Covered       |
+| PUT    | `/moderation/reviews/:reviewId`            | Moderator        | Next.js | Unmigrated                   | Covered       |
+| DELETE | `/moderation/reviews/:reviewId`            | Moderator        | Next.js | Unmigrated                   | Covered       |
+| GET    | `/admin/users`                             | Admin            | Next.js | Unmigrated                   | Covered       |
+| DELETE | `/admin/users/:userId`                     | Admin            | Next.js | Unmigrated                   | Covered       |
+| PATCH  | `/admin/users/:userId/role`                | Admin            | Next.js | Unmigrated                   | Covered       |
+| POST   | `/admin/users/:userId/ban`                 | Admin            | Next.js | Unmigrated                   | Covered       |
+| POST   | `/admin/users/:userId/unban`               | Admin            | Next.js | Unmigrated                   | Covered       |
+| POST   | `/admin/users/:userId/verify`              | Admin            | Next.js | Unmigrated                   | Covered       |
+| POST   | `/admin/users/:userId/resend-verification` | Admin            | Next.js | Unmigrated                   | Covered       |
+| POST   | `/admin/styles`                            | Admin            | Next.js | Unmigrated                   | Covered       |
+| PUT    | `/admin/styles/:styleId`                   | Admin            | Next.js | Unmigrated                   | Covered       |
+| DELETE | `/admin/styles/:styleId`                   | Admin            | Next.js | Unmigrated                   | Covered       |
+| POST   | `/admin/brands`                            | Admin            | Next.js | Unmigrated                   | Covered       |
+| PUT    | `/admin/brands/:brandId`                   | Admin            | Next.js | Unmigrated                   | Covered       |
+| DELETE | `/admin/brands/:brandId`                   | Admin            | Next.js | Unmigrated                   | Covered       |
+| POST   | `/admin/variants`                          | Admin            | Next.js | Unmigrated                   | Covered       |
+| PUT    | `/admin/variants/:variantId`               | Admin            | Next.js | Unmigrated                   | Covered       |
+| DELETE | `/admin/variants/:variantId`               | Admin            | Next.js | Unmigrated                   | Covered       |
+| POST   | `/admin/locations`                         | Admin            | Next.js | Unmigrated                   | Covered       |
+| POST   | `/admin/offers`                            | Admin            | Next.js | Unmigrated                   | Covered       |
+| POST   | `/test/auth-links`                         | Test mode only   | Next.js | Unmigrated                   | Covered       |
 
 ## Shared Shapes
 
@@ -367,6 +367,8 @@ ReviewWithAuthor & {
 
 Auth: public.
 
+Migration status: Rust implementation exists; public traffic still routes to Next.js until route switching is enabled.
+
 Request: no query or body.
 
 Success: `200` when healthy, `503` when degraded. Both responses still use the JSON success envelope.
@@ -385,6 +387,8 @@ Success: `200` when healthy, `503` when degraded. Both responses still use the J
 ### `GET /metrics`
 
 Auth: public.
+
+Migration status: Rust implementation exists; public traffic still routes to Next.js until route switching is enabled.
 
 Request: no query or body.
 
@@ -459,6 +463,8 @@ Errors:
 ### `GET /beer-styles`
 
 Auth: public.
+
+Migration status: Rust implementation exists; public traffic still routes to Next.js until route switching is enabled.
 
 Request: no query or body.
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "next build",
     "start": "npm run start:standalone",
     "start:standalone": "node scripts/start-standalone.mjs",
+    "route-switch:dev": "node scripts/local-route-switch.mjs",
     "perf:capture-directory-sql": "tsx scripts/capture-directory-query-sql.ts",
     "perf:explain-directory": "tsx scripts/explain-directory-queries.ts",
     "test": "jest",

--- a/scripts/local-route-switch.mjs
+++ b/scripts/local-route-switch.mjs
@@ -4,7 +4,10 @@ const port = Number(process.env.ROUTE_SWITCH_PORT ?? "3100");
 const nextBaseUrl = process.env.NEXT_API_BASE_URL ?? "http://localhost:3000";
 const rustBaseUrl = process.env.RUST_API_BASE_URL ?? "http://localhost:4000";
 
-const rustRoutes = [{ method: "GET", path: "/api/v1/health" }];
+const rustRoutes = [
+  { method: "GET", path: "/api/v1/health" },
+  { method: "GET", path: "/api/v1/beer-styles" },
+];
 
 const hopByHopHeaders = new Set([
   "connection",
@@ -56,7 +59,11 @@ function responseHeadersForProxy(response) {
 }
 
 function hasRequestBody(request) {
-  return request.method !== "GET" && request.method !== "HEAD";
+  return (
+    request.method !== "GET" &&
+    request.method !== "HEAD" &&
+    (Number(request.headers["content-length"] ?? "0") > 0 || request.headers["transfer-encoding"])
+  );
 }
 
 async function proxyRequest(request, response) {

--- a/scripts/local-route-switch.mjs
+++ b/scripts/local-route-switch.mjs
@@ -1,0 +1,112 @@
+import http from "node:http";
+
+const port = Number(process.env.ROUTE_SWITCH_PORT ?? "3100");
+const nextBaseUrl = process.env.NEXT_API_BASE_URL ?? "http://localhost:3000";
+const rustBaseUrl = process.env.RUST_API_BASE_URL ?? "http://localhost:4000";
+
+const rustRoutes = [{ method: "GET", path: "/api/v1/health" }];
+
+const hopByHopHeaders = new Set([
+  "connection",
+  "content-encoding",
+  "content-length",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+function targetBaseUrlFor(request) {
+  const url = new URL(request.url ?? "/", "http://localhost");
+  const route = rustRoutes.find(
+    (candidate) => candidate.method === request.method && candidate.path === url.pathname,
+  );
+
+  return route ? rustBaseUrl : nextBaseUrl;
+}
+
+function requestHeadersForProxy(request, targetUrl) {
+  const headers = new Headers();
+
+  for (const [name, value] of Object.entries(request.headers)) {
+    if (hopByHopHeaders.has(name) || value === undefined) {
+      continue;
+    }
+
+    headers.set(name, Array.isArray(value) ? value.join(", ") : value);
+  }
+
+  headers.set("host", targetUrl.host);
+  return headers;
+}
+
+function responseHeadersForProxy(response) {
+  const headers = [];
+
+  response.headers.forEach((value, name) => {
+    if (!hopByHopHeaders.has(name)) {
+      headers.push([name, value]);
+    }
+  });
+
+  return headers;
+}
+
+function hasRequestBody(request) {
+  return request.method !== "GET" && request.method !== "HEAD";
+}
+
+async function proxyRequest(request, response) {
+  const targetBaseUrl = targetBaseUrlFor(request);
+  const targetUrl = new URL(request.url ?? "/", targetBaseUrl);
+
+  const upstreamResponse = await fetch(targetUrl, {
+    method: request.method,
+    headers: requestHeadersForProxy(request, targetUrl),
+    body: hasRequestBody(request) ? request : undefined,
+    duplex: "half",
+    redirect: "manual",
+  });
+
+  response.writeHead(upstreamResponse.status, responseHeadersForProxy(upstreamResponse));
+
+  if (!upstreamResponse.body) {
+    response.end();
+    return;
+  }
+
+  await upstreamResponse.body.pipeTo(
+    new WritableStream({
+      write(chunk) {
+        response.write(chunk);
+      },
+      close() {
+        response.end();
+      },
+      abort(error) {
+        response.destroy(error);
+      },
+    }),
+  );
+}
+
+const server = http.createServer((request, response) => {
+  proxyRequest(request, response).catch((error) => {
+    console.error(error);
+    if (!response.headersSent) {
+      response.writeHead(502, { "content-type": "text/plain; charset=utf-8" });
+    }
+    response.end("Bad Gateway");
+  });
+});
+
+server.listen(port, () => {
+  console.log(`Local route switch listening on http://localhost:${port}`);
+  console.log(`Next fallback: ${nextBaseUrl}`);
+  for (const route of rustRoutes) {
+    console.log(`Rust route: ${route.method} ${route.path} -> ${rustBaseUrl}`);
+  }
+});

--- a/scripts/local-route-switch.mjs
+++ b/scripts/local-route-switch.mjs
@@ -1,4 +1,6 @@
 import http from "node:http";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 
 const port = Number(process.env.ROUTE_SWITCH_PORT ?? "3100");
 const nextBaseUrl = process.env.NEXT_API_BASE_URL ?? "http://localhost:3000";
@@ -9,9 +11,8 @@ const rustRoutes = [
   { method: "GET", path: "/api/v1/beer-styles" },
 ];
 
-const hopByHopHeaders = new Set([
+const requestHopByHopHeaders = new Set([
   "connection",
-  "content-encoding",
   "content-length",
   "keep-alive",
   "proxy-authenticate",
@@ -22,8 +23,24 @@ const hopByHopHeaders = new Set([
   "upgrade",
 ]);
 
-function targetBaseUrlFor(request) {
-  const url = new URL(request.url ?? "/", "http://localhost");
+const responseHeadersToSkip = new Set([...requestHopByHopHeaders, "content-encoding"]);
+
+function requestTargetFor(request) {
+  const requestTarget = request.url ?? "/";
+  if (requestTarget === "*") {
+    return "/";
+  }
+
+  const url = new URL(requestTarget, "http://localhost");
+  if (!requestTarget.startsWith("/") || url.origin !== "http://localhost") {
+    return null;
+  }
+
+  return `${url.pathname}${url.search}`;
+}
+
+function targetBaseUrlFor(request, requestTarget) {
+  const url = new URL(requestTarget, "http://localhost");
   const route = rustRoutes.find(
     (candidate) => candidate.method === request.method && candidate.path === url.pathname,
   );
@@ -35,7 +52,7 @@ function requestHeadersForProxy(request, targetUrl) {
   const headers = new Headers();
 
   for (const [name, value] of Object.entries(request.headers)) {
-    if (hopByHopHeaders.has(name) || value === undefined) {
+    if (requestHopByHopHeaders.has(name) || value === undefined) {
       continue;
     }
 
@@ -50,10 +67,14 @@ function responseHeadersForProxy(response) {
   const headers = [];
 
   response.headers.forEach((value, name) => {
-    if (!hopByHopHeaders.has(name)) {
+    if (name !== "set-cookie" && !responseHeadersToSkip.has(name)) {
       headers.push([name, value]);
     }
   });
+
+  for (const value of response.headers.getSetCookie()) {
+    headers.push(["set-cookie", value]);
+  }
 
   return headers;
 }
@@ -67,8 +88,15 @@ function hasRequestBody(request) {
 }
 
 async function proxyRequest(request, response) {
-  const targetBaseUrl = targetBaseUrlFor(request);
-  const targetUrl = new URL(request.url ?? "/", targetBaseUrl);
+  const requestTarget = requestTargetFor(request);
+  if (!requestTarget) {
+    response.writeHead(400, { "content-type": "text/plain; charset=utf-8" });
+    response.end("Bad Request");
+    return;
+  }
+
+  const targetBaseUrl = targetBaseUrlFor(request, requestTarget);
+  const targetUrl = new URL(requestTarget, targetBaseUrl);
 
   const upstreamResponse = await fetch(targetUrl, {
     method: request.method,
@@ -85,33 +113,27 @@ async function proxyRequest(request, response) {
     return;
   }
 
-  await upstreamResponse.body.pipeTo(
-    new WritableStream({
-      write(chunk) {
-        response.write(chunk);
-      },
-      close() {
-        response.end();
-      },
-      abort(error) {
-        response.destroy(error);
-      },
-    }),
-  );
+  await pipeline(Readable.fromWeb(upstreamResponse.body), response);
 }
 
 const server = http.createServer((request, response) => {
   proxyRequest(request, response).catch((error) => {
     console.error(error);
-    if (!response.headersSent) {
-      response.writeHead(502, { "content-type": "text/plain; charset=utf-8" });
+    if (response.headersSent) {
+      response.destroy(error instanceof Error ? error : new Error(String(error)));
+      return;
     }
+
+    response.writeHead(502, { "content-type": "text/plain; charset=utf-8" });
     response.end("Bad Gateway");
   });
 });
 
-server.listen(port, () => {
-  console.log(`Local route switch listening on http://localhost:${port}`);
+server.listen({ host: "127.0.0.1", port }, () => {
+  const address = server.address();
+  const actualPort = address && typeof address === "object" ? address.port : port;
+
+  console.log(`Local route switch listening on http://127.0.0.1:${actualPort}`);
   console.log(`Next fallback: ${nextBaseUrl}`);
   for (const route of rustRoutes) {
     console.log(`Rust route: ${route.method} ${route.path} -> ${rustBaseUrl}`);


### PR DESCRIPTION
## Changes

- Add `CONTRACT_TEST_PATTERN` environment variable to filter contract tests by comma-separated substrings matching contract names or request paths
- Create local HTTP proxy server for routing requests between Next.js and Rust APIs based on configurable route patterns
- Proxy listens on port 3100 by default; routes GET `/api/v1/health` to Rust, all other requests to Next.js
- Add configurable environment variables: `ROUTE_SWITCH_PORT`, `NEXT_API_BASE_URL`, `RUST_API_BASE_URL`
- Add `route-switch:dev` npm script to start the proxy