### PR TITLE
ci: improve docker build cache handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,6 @@ jobs:
           target: runner
           push: true
           cache-from: type=gha,scope=kiebex
-          cache-to: type=gha,scope=kiebex,mode=max
           tags: |
             ghcr.io/${{ env.OWNER_LC }}/kiebex:pr-${{ github.event.number }}-${{ github.sha }}
             ghcr.io/${{ env.OWNER_LC }}/kiebex:pr-${{ github.event.number }}
@@ -192,7 +191,6 @@ jobs:
           cache-from: |
             type=gha,scope=kiebex-migrate
             type=gha,scope=kiebex
-          cache-to: type=gha,scope=kiebex-migrate,mode=max
           tags: |
             ghcr.io/${{ env.OWNER_LC }}/kiebex-migrate:pr-${{ github.event.number }}-${{ github.sha }}
             ghcr.io/${{ env.OWNER_LC }}/kiebex-migrate:pr-${{ github.event.number }}
@@ -205,7 +203,6 @@ jobs:
           target: api-runner
           push: true
           cache-from: type=gha,scope=kiebex-api
-          cache-to: type=gha,scope=kiebex-api,mode=max
           tags: |
             ghcr.io/${{ env.OWNER_LC }}/kiebex-api:pr-${{ github.event.number }}-${{ github.sha }}
             ghcr.io/${{ env.OWNER_LC }}/kiebex-api:pr-${{ github.event.number }}

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -48,7 +48,7 @@ jobs:
           target: runner
           push: ${{ github.ref_name == 'main' }}
           cache-from: type=gha,scope=kiebex
-          cache-to: type=gha,scope=kiebex,mode=max
+          cache-to: type=gha,scope=kiebex,mode=max,ignore-error=true
           tags: |
             ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE }}:latest
             ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE }}:${{ github.sha }}
@@ -63,7 +63,7 @@ jobs:
           cache-from: |
             type=gha,scope=kiebex-migrate
             type=gha,scope=kiebex
-          cache-to: type=gha,scope=kiebex-migrate,mode=max
+          cache-to: type=gha,scope=kiebex-migrate,mode=max,ignore-error=true
           tags: |
             ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE }}-migrate:latest
             ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE }}-migrate:${{ github.sha }}
@@ -76,7 +76,7 @@ jobs:
           target: api-runner
           push: ${{ github.ref_name == 'main' }}
           cache-from: type=gha,scope=kiebex-api
-          cache-to: type=gha,scope=kiebex-api,mode=max
+          cache-to: type=gha,scope=kiebex-api,mode=max,ignore-error=true
           tags: |
             ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.API_IMAGE }}:latest
             ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.API_IMAGE }}:${{ github.sha }}


### PR DESCRIPTION
Add ignore-error=true to cache-to in image.yml to prevent
build failures when cache upload encounters errors. Remove
cache-to from ci.yml pull request builds since they don't
need to persist cache, reducing unnecessary overhead and
potential failure points in PR workflows.