### PR TITLE
build(deps): bump React and React DOM to 19.2.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,8 @@
         "pg": "^8.20.0",
         "prisma": "^7.9.1",
         "prom-client": "^15.1.3",
-        "react": "19.2.5",
-        "react-dom": "19.2.5",
+        "react": "19.2.8",
+        "react-dom": "19.2.8",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -4532,9 +4532,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -11294,24 +11294,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.5"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "pg": "^8.20.0",
     "prisma": "^7.9.1",
     "prom-client": "^15.1.3",
-    "react": "19.2.5",
-    "react-dom": "19.2.5",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
     "zod": "^4.4.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Updates `react` and `react-dom` from `19.2.5` to `19.2.8` together.
- Refreshes the locked `@types/react` package from `19.2.14` to `19.2.17`.

## Why

React and React DOM must use compatible versions. The two original Dependabot updates each changed only one half of the pair, causing CI to fail: one with a React/React DOM runtime-version mismatch and the other during `npm ci` because of React DOM's peer dependency. Combining the updates keeps the packages in sync and makes the dependency graph resolvable.

## Original Dependabot PRs

This PR combines and supersedes:

- #81 — `react` and `@types/react`
- #103 — `react-dom`

## Validation

- `npm ci`
- `npx jest __tests__/components/public-directory-links.test.tsx`

The focused test suite that previously failed because of the React version mismatch now passes.